### PR TITLE
update z-index of the spinner overlay so it goes behind navbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "PRX Angular 2 style guide library",
   "keywords": [
     "PRX",

--- a/src/lib/src/spinner/spinner.component.css
+++ b/src/lib/src/spinner/spinner.component.css
@@ -67,7 +67,7 @@
 }
 .overlay {
   position: absolute;
-  z-index: 998;
+  z-index: 199;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
The z-index of the `<header>` in the navbar is 200, so 199 for the overlay to come in behind it.