### PR TITLE
No footer beta notice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "PRX Angular 2 style guide library",
   "keywords": [
     "PRX",

--- a/src/demo/app/app.component.ts
+++ b/src/demo/app/app.component.ts
@@ -15,7 +15,12 @@ import { Component } from '@angular/core';
         <router-outlet></router-outlet>
       </article>
     </main>
-    <prx-footer></prx-footer>
+    <prx-footer>
+      <p>
+        And also some footer content, including a <a href="#">link to something</a>.
+      </p>
+      <a href="#">And also a standalone link</a>
+    </prx-footer>
     <prx-toastr></prx-toastr>
   `,
   styles: [`

--- a/src/demo/app/footer/footer-demo.component.ts
+++ b/src/demo/app/footer/footer-demo.component.ts
@@ -9,6 +9,9 @@ import {Component} from '@angular/core';
         The Footer Component provides an HTML5 footer element containing various PRX links.
         You can see an example of this footer component in the demo application below.
       </p>
+      <p>
+        Any content inside the prx-footer will be projected into the left-most column.
+      </p>
       <dl>
         <dt>module</dt><dd><code>FooterModule</code></dd>
         <dt>selector</dt><dd><code>prx-footer</code></dd>
@@ -16,7 +19,12 @@ import {Component} from '@angular/core';
       <aside>
         Usage:
         <pre class="code">
-          &lt;prx-footer&gt;&lt;/prx-footer&gt;
+          &lt;prx-footer&gt;
+            &lt;p&gt;
+              And also some footer content, including a &lt;a href="#"&gt;link to something&lt;/a&gt;.
+            &lt;/p&gt;
+            &lt;a href="#"&gt;And also a standalone link&lt;/a&gt;
+          &lt;/prx-footer&gt;
         </pre>
       </aside>
     </section>

--- a/src/lib/src/footer/footer.component.css
+++ b/src/lib/src/footer/footer.component.css
@@ -99,31 +99,31 @@ footer {
 }
 
 /*
- * Temp notice of beta
+ * Projected content in left-most column
  */
-.columns .beta-notice {
+.columns .footer-left {
   font-size: 10px;
   margin-right: auto;
   margin-left: auto;
   max-width: 300px;
 }
-.columns .beta-notice >>> p {
+.columns .footer-left >>> p {
   font-size: 1em;
   padding-right: 15px;
   padding-left: 15px;
 }
-.columns .beta-notice >>> p a {
+.columns .footer-left >>> p a {
   font-size: inherit;
   display: inline;
   line-height: 1em;
 }
-.columns .beta-notice >>> a {
+.columns .footer-left >>> a {
   display: block;
   line-height: 3rem;
   font-size: 1.125em;
 }
 @media screen and (min-width: 768px) {
-  .columns .beta-notice {
+  .columns .footer-left {
     padding-top: 3rem;
     font-size: 12px;
   }

--- a/src/lib/src/footer/footer.component.css
+++ b/src/lib/src/footer/footer.component.css
@@ -107,16 +107,17 @@ footer {
   margin-left: auto;
   max-width: 300px;
 }
-.columns .beta-notice p {
+.columns .beta-notice >>> p {
   font-size: 1em;
   padding-right: 15px;
   padding-left: 15px;
 }
-.columns .beta-notice p a {
+.columns .beta-notice >>> p a {
   font-size: inherit;
-  display: inline !important;
+  display: inline;
+  line-height: 1em;
 }
-.columns .beta-notice > a {
+.columns .beta-notice >>> a {
   display: block;
   line-height: 3rem;
   font-size: 1.125em;

--- a/src/lib/src/footer/footer.component.spec.ts
+++ b/src/lib/src/footer/footer.component.spec.ts
@@ -1,20 +1,29 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
+import { DebugElement, Component } from '@angular/core';
 import { FooterComponent } from './footer.component';
 
+@Component({
+  selector: 'test-component',
+  template: `
+    <prx-footer>
+      Some projected content
+    </prx-footer>
+  `
+})
+class TestComponent {}
+
 describe('FooterComponent', () => {
-  let comp: FooterComponent;
-  let fix: ComponentFixture<FooterComponent>;
+  let comp: TestComponent;
+  let fix: ComponentFixture<TestComponent>;
   let de: DebugElement;
   let el: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [FooterComponent]
+      declarations: [TestComponent, FooterComponent]
     }).compileComponents().then(() => {
-
-      fix = TestBed.createComponent(FooterComponent);
+      fix = TestBed.createComponent(TestComponent);
       comp = fix.componentInstance;
       de = fix.debugElement;
       el = de.nativeElement;
@@ -22,14 +31,12 @@ describe('FooterComponent', () => {
   }));
 
   it('renders the footer', () => {
-    expect(de.nativeElement.innerText).toContain(`You're seeing a beta preview of prx.org`);
+    expect(de.nativeElement.innerText).toContain('About Us');
+    expect(de.nativeElement.innerText).toContain('Radiotopia');
   });
 
-  it('uses the path in the old version link', () => {
-    spyOn(comp, 'locationPath').and.returnValue('/foobar');
-    fix.detectChanges();
-    expect(de.query(By.css('a.old-version')).nativeElement.innerText).toContain('Use Old Version');
-    expect(de.query(By.css('a.old-version')).nativeElement.getAttribute('href')).toEqual('http://www.prx.org/foobar?m=false');
+  it('projects inner content', () => {
+    expect(de.nativeElement.innerText).toContain('Some projected content');
   });
 
 });

--- a/src/lib/src/footer/footer.component.ts
+++ b/src/lib/src/footer/footer.component.ts
@@ -45,14 +45,4 @@ import { Component } from '@angular/core';
     `
 })
 
-export class FooterComponent {
-
-  locationPath(): string {
-    return window.location.pathname;
-  }
-
-  desktopUrl(): string {
-    return `http://www.prx.org${this.locationPath()}?m=false`;
-  }
-
-}
+export class FooterComponent {}

--- a/src/lib/src/footer/footer.component.ts
+++ b/src/lib/src/footer/footer.component.ts
@@ -9,12 +9,7 @@ import { Component } from '@angular/core';
       <div class="columns">
         <section>
           <div class="beta-notice">
-            <p>
-              You're seeing a beta preview of prx.org.
-              <a href="http://help.prx.org/anonymous_requests/new">Let us know</a>
-              what you think.
-            </p>
-            <a class="old-version" [href]="desktopUrl()">Use Old Version</a>
+            <ng-content></ng-content>
           </div>
         </section>
         <section>

--- a/src/lib/src/footer/footer.component.ts
+++ b/src/lib/src/footer/footer.component.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
     <footer>
       <div class="columns">
         <section>
-          <div class="beta-notice">
+          <div class="footer-left">
             <ng-content></ng-content>
           </div>
         </section>


### PR DESCRIPTION
See PRX/metrics.prx.org#86

Removes beta boilerplate from footer ... but leaves an `<ng-content>` in case we want to add something app-specific later on.  And to make me feel better about myself.