### PR TITLE
Unset image src when it changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "PRX Angular 2 style guide library",
   "keywords": [
     "PRX",

--- a/src/lib/src/image/image-loader.component.spec.ts
+++ b/src/lib/src/image/image-loader.component.spec.ts
@@ -88,7 +88,7 @@ describe('ImageLoaderComponent', () => {
         expect(de.query(By.css('img')).nativeElement.getAttribute('src')).toEqual('http://fillmurray.com/10/10');
         expect(getBackground()).toEqual('http://fillmurray.com/10/10');
         comp.ngOnChanges(<any> {imageDoc: mockDoc(null)});
-        expect(getBackground()).toEqual('');
+        expect(getBackground()).toMatch('data:image/gif;base64');
         done();
       });
 

--- a/src/lib/src/image/image-loader.component.spec.ts
+++ b/src/lib/src/image/image-loader.component.spec.ts
@@ -87,18 +87,20 @@ describe('ImageLoaderComponent', () => {
       waitFor('onLoad', () => {
         expect(de.query(By.css('img')).nativeElement.getAttribute('src')).toEqual('http://fillmurray.com/10/10');
         expect(getBackground()).toEqual('http://fillmurray.com/10/10');
+        comp.ngOnChanges(<any> {imageDoc: mockDoc(null)});
+        expect(getBackground()).toEqual('');
         done();
       });
 
       // TODO: ngOnChanges not firing (https://github.com/angular/angular/issues/9866)
-      comp.ngOnChanges();
+      comp.ngOnChanges({});
       fix.detectChanges();
     });
 
     it('shows a placeholder for missing images', () => {
       comp.imageDoc = mockDoc(null);
       // TODO: ngOnChanges not firing (https://github.com/angular/angular/issues/9866)
-      comp.ngOnChanges();
+      comp.ngOnChanges({});
       expect(getClasslist().contains('placeholder')).toBeTruthy();
     });
 
@@ -111,7 +113,7 @@ describe('ImageLoaderComponent', () => {
       });
 
       // TODO: ngOnChanges not firing (https://github.com/angular/angular/issues/9866)
-      comp.ngOnChanges();
+      comp.ngOnChanges({});
       fix.detectChanges();
     });
 

--- a/src/lib/src/image/image-loader.component.ts
+++ b/src/lib/src/image/image-loader.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ElementRef, OnChanges } from '@angular/core';
+import { Component, Input, ElementRef, OnChanges, SimpleChanges } from '@angular/core';
 import { HalDoc } from '../hal/doc/haldoc';
 
 @Component({
@@ -17,7 +17,11 @@ export class ImageLoaderComponent implements OnChanges {
   constructor(private element: ElementRef) {}
 
   setBackgroundImage(src: string) {
-    this.element.nativeElement.style['background-image'] = `url(${src})`;
+    if (src) {
+      this.element.nativeElement.style['background-image'] = `url(${src})`;
+    } else {
+      this.element.nativeElement.style['background-image'] = null;
+    }
   }
 
   setPlaceholder(isError: boolean) {
@@ -32,7 +36,11 @@ export class ImageLoaderComponent implements OnChanges {
 
   onError = () => this.setPlaceholder(true);
 
-  ngOnChanges() {
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.imageDoc) {
+      this.src = null;
+      this.setBackgroundImage(null);
+    }
     if (!this.src) {
       if (this.imageDoc && this.imageDoc.has('prx:image')) {
         this.imageDoc.follow('prx:image').subscribe(

--- a/src/lib/src/image/image-loader.component.ts
+++ b/src/lib/src/image/image-loader.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input, ElementRef, OnChanges, SimpleChanges } from '@angular/core';
 import { HalDoc } from '../hal/doc/haldoc';
 
+const PLACEHOLDER = 'url("data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=")';
+
 @Component({
   moduleId: module.id,
   selector: 'prx-image',
@@ -20,7 +22,7 @@ export class ImageLoaderComponent implements OnChanges {
     if (src) {
       this.element.nativeElement.style['background-image'] = `url(${src})`;
     } else {
-      this.element.nativeElement.style['background-image'] = null;
+      this.element.nativeElement.style['background-image'] = PLACEHOLDER;
     }
   }
 


### PR DESCRIPTION
When an image changes, unset the `src`, so we (1) go back to a blank loader, and (2) show the new haldoc's image.