### PR TITLE
Image loader part 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "PRX Angular 2 style guide library",
   "keywords": [
     "PRX",

--- a/src/demo/app/image/image-loader-demo.component.css
+++ b/src/demo/app/image/image-loader-demo.component.css
@@ -1,4 +1,5 @@
 prx-image {
-  width: 40px;
-  height: 40px;
+  width: 60px;
+  height: 60px;
+  border: 1px solid #444;
 }

--- a/src/demo/app/image/image-loader-demo.component.ts
+++ b/src/demo/app/image/image-loader-demo.component.ts
@@ -1,5 +1,5 @@
-import {Component} from '@angular/core';
-import { HalService, HalDoc } from 'ngx-prx-styleguide';
+import { Component } from '@angular/core';
+import { MockHalDoc } from 'ngx-prx-styleguide';
 
 @Component({
   moduleId: module.id,
@@ -11,7 +11,7 @@ import { HalService, HalDoc } from 'ngx-prx-styleguide';
         The Image Loader Component loads an image from a url or a haldoc.
       </p>
       <p>
-        Because it uses <code>background-image</code> for display, the <code>prx-image</code> element should be given a width 
+        Because it uses <code>background-image</code> for display, the <code>prx-image</code> element should be given a width
         and a height. It defaults to <code>display: inline-block</code> but can be overridden to <code>display: block</code>.
       </p>
       <p>
@@ -27,20 +27,30 @@ import { HalService, HalDoc } from 'ngx-prx-styleguide';
         <li><code>@Input() imageDoc: HalDoc</code> - load image from a HalDoc containing a <code>prx-image</code></li>
       </ul>
       <aside>
-        Usage <code>src</code>:
+        Usage:
         <pre class="code">
-          &lt;prx-image src="http://fake.url/doesnotexist.png"&gt;&lt;/prx-image&gt;
+          &lt;prx-image [src]="pickSrc" [imageDoc]="pickDoc"&gt;&lt;/prx-image&gt;
         </pre>
         Example:
-        <prx-image src="http://fake.url/doesnotexist.png"></prx-image>
-      </aside>
-      <aside>
-        Usage <code>imageDoc</code>:
-        <pre class="code">
-          &lt;prx-image [imageDoc]="storyDoc"&gt;&lt;/prx-image&gt;
-        </pre>
-        Example:
-        <prx-image *ngIf="storyDoc" [imageDoc]="storyDoc"></prx-image>
+        <br/>
+        <prx-image [src]="pickSrc" [imageDoc]="pickDoc"></prx-image>
+        <p class="form-group">
+          <label>Pick a Src</label>
+          <select [(ngModel)]="pickSrc">
+            <option value="">None</option>
+            <option value="http://placebear.com/g/1000/1000">Actual URL</option>
+            <option value="http://fake.url/doesnotexist.png">Bad URL</option>
+          </select>
+        </p>
+        <p class="form-group">
+          <label>Pick an Image Doc</label>
+          <select [ngModel]="whichDoc" (ngModelChange)="setDoc($event)">
+            <option value="">None</option>
+            <option value="good">Doc with image</option>
+            <option value="medium">Doc without image</option>
+            <option value="bad">Doc with error</option>
+          </select>
+        </p>
       </aside>
     </section>
   `,
@@ -48,14 +58,23 @@ import { HalService, HalDoc } from 'ngx-prx-styleguide';
 })
 
 export class ImageLoaderDemoComponent {
-  cmsHost = 'cms-staging.prx.tech';
-  storyDoc: HalDoc;
 
-  constructor(private hal: HalService) {
-    this.loadCmsStory();
-  }
+  pickSrc = '';
+  whichDoc = '';
+  pickDoc: MockHalDoc;
 
-  loadCmsStory() {
-    this.hal.public(this.cmsHost).follow('prx:story', {id: 187931}).subscribe(doc => this.storyDoc = doc);
+  setDoc(which: string) {
+    if (which === 'good') {
+      this.pickDoc = new MockHalDoc({});
+      this.pickDoc.mock('prx:image', {_links: {enclosure: {href: 'http://placebear.com/1000/1000'}}});
+    } else if (which === 'medium') {
+      this.pickDoc = new MockHalDoc({});
+    } else if (which === 'bad') {
+      this.pickDoc = new MockHalDoc({});
+      this.pickDoc.mockError('prx:image', 'something went horribly wrong');
+      this.pickDoc.has = () => true; // TODO: mockError not showing in has()
+    } else {
+      this.pickDoc = null;
+    }
   }
 }

--- a/src/lib/src/image/image-loader.component.spec.ts
+++ b/src/lib/src/image/image-loader.component.spec.ts
@@ -31,16 +31,6 @@ describe('ImageLoaderComponent', () => {
     });
   };
 
-  const getBackground = () => {
-    let style = de.nativeElement.getAttribute('style') || '';
-    let match = style.match(/background-image: url\((.+)\)/);
-    return match ? match[1].replace(/^"|"$/g, '') : '';
-  };
-
-  const getClasslist = () => {
-    return de.nativeElement.classList;
-  };
-
   const mockDoc = (linkHref: string) => {
     let doc = cms.mock('prx:anything', {});
     if (linkHref) {
@@ -56,9 +46,9 @@ describe('ImageLoaderComponent', () => {
       waitFor('onLoad', () => {
         let imageEl = de.query(By.css('img'));
         expect(de.query(By.css('img')).nativeElement.getAttribute('src')).toEqual('http://fillmurray.com/10/10');
-        expect(getBackground()).toEqual('http://fillmurray.com/10/10');
-        expect(getClasslist().contains('placeholder')).toBeFalsy();
-        expect(getClasslist().contains('placeholder-error')).toBeFalsy();
+        expect(comp.background).toMatch('http://fillmurray.com/10/10');
+        expect(comp.isPlaceholder).toBeFalsy();
+        expect(comp.isError).toBeFalsy();
         done();
       });
       fix.detectChanges();
@@ -72,7 +62,7 @@ describe('ImageLoaderComponent', () => {
       comp.src = 'http://foo.bar/this/is/fake.jpg';
       waitFor('onError', () => {
         expect(de.query(By.css('img')).nativeElement.getAttribute('src')).toEqual('http://foo.bar/this/is/fake.jpg');
-        expect(getClasslist().contains('placeholder-error')).toBeTruthy();
+        expect(comp.isError).toBeTruthy();
         done();
       });
       fix.detectChanges();
@@ -86,34 +76,35 @@ describe('ImageLoaderComponent', () => {
       comp.imageDoc = mockDoc('http://fillmurray.com/10/10');
       waitFor('onLoad', () => {
         expect(de.query(By.css('img')).nativeElement.getAttribute('src')).toEqual('http://fillmurray.com/10/10');
-        expect(getBackground()).toEqual('http://fillmurray.com/10/10');
-        comp.ngOnChanges(<any> {imageDoc: mockDoc(null)});
-        expect(getBackground()).toMatch('data:image/gif;base64');
+        expect(comp.background).toMatch('http://fillmurray.com/10/10');
+        comp.imageDoc = mockDoc(null);
+        comp.ngOnChanges(<any> {imageDoc: true});
+        expect(comp.background).toBeNull();
         done();
       });
 
       // TODO: ngOnChanges not firing (https://github.com/angular/angular/issues/9866)
-      comp.ngOnChanges({});
+      comp.ngOnChanges(<any> {imageDoc: true});
       fix.detectChanges();
     });
 
     it('shows a placeholder for missing images', () => {
       comp.imageDoc = mockDoc(null);
       // TODO: ngOnChanges not firing (https://github.com/angular/angular/issues/9866)
-      comp.ngOnChanges({});
-      expect(getClasslist().contains('placeholder')).toBeTruthy();
+      comp.ngOnChanges(<any> {imageDoc: true});
+      expect(comp.isPlaceholder).toBeTruthy();
     });
 
     it('shows an error for bad enclosure href', (done: any) => {
       comp.imageDoc = mockDoc('http://foo.bar/this/is/fake.jpg');
       waitFor('onError', () => {
         expect(de.query(By.css('img')).nativeElement.getAttribute('src')).toEqual('http://foo.bar/this/is/fake.jpg');
-        expect(getClasslist().contains('placeholder-error')).toBeTruthy();
+        expect(comp.isError).toBeTruthy();
         done();
       });
 
       // TODO: ngOnChanges not firing (https://github.com/angular/angular/issues/9866)
-      comp.ngOnChanges({});
+      comp.ngOnChanges(<any> {imageDoc: true});
       fix.detectChanges();
     });
 

--- a/src/lib/src/image/image-loader.component.ts
+++ b/src/lib/src/image/image-loader.component.ts
@@ -1,13 +1,12 @@
-import { Component, Input, ElementRef, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, HostBinding } from '@angular/core';
 import { HalDoc } from '../hal/doc/haldoc';
-
-const PLACEHOLDER = 'url("data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=")';
 
 @Component({
   moduleId: module.id,
   selector: 'prx-image',
   template: `
     <img *ngIf="src" [src]="src" (load)="onLoad()" (error)="onError()"/>
+    <img *ngIf="docSrc" [src]="docSrc" (load)="onLoad()" (error)="onError()"/>
   `,
   styleUrls: ['./image-loader.component.css']
 })
@@ -15,46 +14,41 @@ const PLACEHOLDER = 'url("data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=
 export class ImageLoaderComponent implements OnChanges {
   @Input() public src: string;
   @Input() public imageDoc: HalDoc;
+  public docSrc: string;
 
-  constructor(private element: ElementRef) {}
-
-  setBackgroundImage(src: string) {
-    if (src) {
-      this.element.nativeElement.style['background-image'] = `url(${src})`;
-    } else {
-      this.element.nativeElement.style['background-image'] = PLACEHOLDER;
-    }
-  }
-
-  setPlaceholder(isError: boolean) {
-    if (isError) {
-      this.element.nativeElement.classList.add('placeholder-error');
-      this.element.nativeElement.style['background-image'] = '';
-    } else {
-      this.element.nativeElement.classList.add('placeholder');
-      this.element.nativeElement.style['background-image'] = '';
-    }
-  }
-
-  onLoad = () => this.setBackgroundImage(this.src);
-
-  onError = () => this.setPlaceholder(true);
+  @HostBinding('style.background-image') background: string;
+  @HostBinding('class.placeholder') isPlaceholder = false;
+  @HostBinding('class.placeholder-error') isError = false;
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.imageDoc) {
-      this.src = null;
-      this.setBackgroundImage(null);
-    }
-    if (!this.src && this.imageDoc) {
-      if (this.imageDoc.has('prx:image')) {
+    if (changes.src) {
+      this.reset();
+    } else if (changes.imageDoc) {
+      this.reset();
+      if (this.imageDoc && this.imageDoc.has('prx:image')) {
         this.imageDoc.follow('prx:image').subscribe(
-          img => this.src = img.expand('enclosure'),
-          err => this.setPlaceholder(true)
+          img => this.docSrc = img.expand('enclosure'),
+          err => this.isError = true,
         );
-      } else {
-        this.setPlaceholder(false);
+      } else if (this.imageDoc) {
+        this.isPlaceholder = true;
       }
     }
+  }
+
+  onLoad() {
+    this.background = `url(${this.src || this.docSrc})`;
+  }
+
+  onError() {
+    this.isError = true;
+  }
+
+  reset() {
+    this.background = null;
+    this.isPlaceholder = false;
+    this.isError = false;
+    this.docSrc = null;
   }
 
 }


### PR DESCRIPTION
Previous ImageLoader version had an issue that could cause Publish to load images in an infinite loop.  So taking my 10th shot at this.

- [x] Create a demo encapsulating all possible use cases (switching inputs, going back to null/placeholder state, etc)
- [x] Get rid of nativeElement manipulation - just use angular bindings
- [x] Reset entire ImageLoader state on changes, then wait for the prx:image / src to load before displaying anything at all.