### PR TITLE
Add authorization check logic to token request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "PRX Angular 2 style guide library",
   "keywords": [
     "PRX",

--- a/src/demo/app/auth/auth-demo.component.ts
+++ b/src/demo/app/auth/auth-demo.component.ts
@@ -26,8 +26,12 @@ import { AuthService } from 'ngx-prx-styleguide';
           </li>
           <li>
             Subscribe to <code>AuthService.token</code> Observable. It will emit
-            null when the user is confirmed to be unauthorized, and a string token
-            when the user is authorized.
+            null when the user is not authenticated, and a string token
+            when the user is authenticated. If the user is authenticated,
+            but not authorized for your application, the token will be set
+            to a special reserved string. You can check for this case
+            with <code>AuthService.parseToken(tokenString)</code> which will
+            return false if the token is not parse-able.
           </li>
         </ol>
         <ul>
@@ -45,7 +49,7 @@ import { AuthService } from 'ngx-prx-styleguide';
           <li>
             Add a <code>&lt;prx-login&gt;</code> component somewhere in your app.
             You probably only want to show it when the <code>AuthService.token</code>
-            emits null/unauthorized.
+            emits null.
           </li>
           <li>
             The <code>&lt;prx-login&gt;</code> component has 2 outputs: (1) a

--- a/src/demo/app/guard/guard-demo.component.ts
+++ b/src/demo/app/guard/guard-demo.component.ts
@@ -16,6 +16,9 @@ import { AuthService } from 'ngx-prx-styleguide';
             Your application should have a <code>'login'</code> route. The <code>AuthGuard</code> Service will redirect to
             this route when the user is not logged in.
           </li>
+          <li>Your application should have a <code>'permission-denied'</code> route. The <code>AuthGuard</code>
+              Service will redirect to this route when the user does not have permission to use your application.
+          </li>
           <li>The <code>prx-auth</code> component should be present and shown somewhere on the page in the component hierarchy.</li>
           <li>Protected routes use <code>canActivate: [AuthGuard], canDeactivate: [DeactivateGuard]</code></li>
           <li>Login route uses <code>canActivate: [UnauthGuard]</code></li>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,6 +6,7 @@ export { TimeseriesChartModel, TimeseriesDatumModel } from './src/charts/models/
 
 export { AuthModule } from './src/auth/auth.module';
 export { AuthService } from './src/auth/auth.service';
+export { Userinfo, UserinfoService } from './src/auth/userinfo.service';
 
 export { BaseModel, RelatedMap, ValidatorMap } from './src/model/base.model';
 export { BaseInvalid, UNLESS_NEW, REQUIRED, LENGTH, IN, FALSEY, TOKENY, URL } from './src/model/base.invalid';

--- a/src/lib/src/auth/auth-parser.ts
+++ b/src/lib/src/auth/auth-parser.ts
@@ -17,7 +17,7 @@ export class AuthParser {
       let parts = pair.split('=');
       data[parts[0]] = parts[1];
     }
-    return data['access_token'];
+    return data['access_token'] || data['error'];
   }
 
 }

--- a/src/lib/src/auth/auth-parser.ts
+++ b/src/lib/src/auth/auth-parser.ts
@@ -11,13 +11,21 @@ export class AuthParser {
     return locationHash.replace(/^#/, '');
   }
 
-  static parseToken(query = ''): string {
+  static queryToPairs(query = ''): {} {
     let data = {};
     for (let pair of query.split('&')) {
       let parts = pair.split('=');
       data[parts[0]] = parts[1];
     }
-    return data['access_token'] || data['error'];
+    return data;
+  }
+
+  static parseToken(query = ''): string {
+    return this.queryToPairs(query)['access_token'];
+  }
+
+  static parseError(query = ''): string {
+    return this.queryToPairs(query)['error'];
   }
 
 }

--- a/src/lib/src/auth/auth.component.ts
+++ b/src/lib/src/auth/auth.component.ts
@@ -61,7 +61,15 @@ export class AuthComponent implements OnChanges, OnDestroy {
     // 1st load has no query, 2nd redirect-load does
     if (query) {
       let token = AuthParser.parseToken(query);
-      this.authService.setToken(token);
+      if (token == 'invalid_scope') {
+        this.authService.setError({
+          name: 'Access Denied',
+          message: 'Sorry, you do not have access to this application.',
+          stack: 'Invalid scope'
+        })
+      } else {
+        this.authService.setToken(token);
+      }
     }
   }
 

--- a/src/lib/src/auth/auth.component.ts
+++ b/src/lib/src/auth/auth.component.ts
@@ -64,11 +64,16 @@ export class AuthComponent implements OnChanges, OnDestroy {
       let error = AuthParser.parseError(query);
       if (error) {
         if (error == 'invalid_scope') {
+          // authz error
           // we don't want to use setError because this error is final.
-          // i.e. we don't want to prompt another login attempt, because
-          // the error is not with authentication, it's with authorization.
+          // i.e. we don't want to prompt another login attempt.
           this.authService.failAuthorization();
+        } else if (error == 'login_required') {
+          // authn error
+          // normal first-pass authn error which triggers login form.
+          this.authService.setToken(null);
         } else {
+          console.log('unexpected auth error', error);
           throw error;
         }
       }

--- a/src/lib/src/auth/auth.component.ts
+++ b/src/lib/src/auth/auth.component.ts
@@ -67,7 +67,7 @@ export class AuthComponent implements OnChanges, OnDestroy {
           // we don't want to use setError because this error is final.
           // i.e. we don't want to prompt another login attempt, because
           // the error is not with authentication, it's with authorization.
-          this.authService.setToken('AUTHORIZATION_FAIL');
+          this.authService.failAuthorization();
         } else {
           throw error;
         }

--- a/src/lib/src/auth/auth.component.ts
+++ b/src/lib/src/auth/auth.component.ts
@@ -61,13 +61,18 @@ export class AuthComponent implements OnChanges, OnDestroy {
     // 1st load has no query, 2nd redirect-load does
     if (query) {
       let token = AuthParser.parseToken(query);
-      if (token == 'invalid_scope') {
-        this.authService.setError({
-          name: 'Access Denied',
-          message: 'Sorry, you do not have access to this application.',
-          stack: 'Invalid scope'
-        })
-      } else {
+      let error = AuthParser.parseError(query);
+      if (error) {
+        if (error == 'invalid_scope') {
+          // we don't want to use setError because this error is final.
+          // i.e. we don't want to prompt another login attempt, because
+          // the error is not with authentication, it's with authorization.
+          this.authService.setToken('AUTHORIZATION_FAIL');
+        } else {
+          throw error;
+        }
+      }
+      if (token) {
         this.authService.setToken(token);
       }
     }

--- a/src/lib/src/auth/auth.module.ts
+++ b/src/lib/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { HttpModule } from '@angular/http';
 import { AuthComponent } from './auth.component';
 import { AuthService } from './auth.service';
 import { LoginComponent } from './login.component';
+import { UserinfoService } from './userinfo.service';
 
 @NgModule({
   imports: [
@@ -16,7 +17,8 @@ import { LoginComponent } from './login.component';
     LoginComponent
   ],
   providers: [
-    AuthService
+    AuthService,
+    UserinfoService
   ],
   exports: [
     AuthComponent,

--- a/src/lib/src/auth/auth.service.spec.ts
+++ b/src/lib/src/auth/auth.service.spec.ts
@@ -5,6 +5,10 @@ describe('AuthService', () => {
   let auth = new AuthService();
   auth.config('some-host', 'some-client-id');
 
+  beforeEach(() => {
+    auth.setToken(undefined);
+  });
+
   describe('url', () => {
 
     it('generates unique nonces', () => {
@@ -25,9 +29,43 @@ describe('AuthService', () => {
 
   });
 
+  describe('failAuthorization', () => {
+
+    it('sets the special token value', () => {
+      let currentToken = 'something';
+      auth.token.subscribe((token) => { currentToken = token; });
+      auth.failAuthorization();
+      expect(currentToken).toEqual(AuthService.AUTHORIZATION_DENIED);
+    });
+
+  });
+
+  describe('parseToken', () => {
+
+    it('returns false when the token is AUTHORIZATION_DENIED', () => {
+      expect(auth.parseToken(AuthService.AUTHORIZATION_DENIED)).toEqual(false);
+    });
+
+    it('throws exception when token is not base64 encoded', () => {
+      expect(() => { auth.parseToken('a header.random string') }).toThrow(new Error('Illegal base64url string!'));
+    });
+
+    it('throws excepption when token is not valid JWT structure', () => {
+      expect(() => { auth.parseToken('invalid jwt') }).toThrow(new Error('Invalid xxxx.yyyy token string structure'));
+
+    it('returns JS object from base64 encoded JSON', () => {
+      let tokenJson = JSON.stringify({ foo: 'bar' });
+      let myToken = 'this-header-is-ignored.' + btoa(tokenJson);
+      console.log(myToken);
+      expect(auth.parseToken(myToken)).toEqual({foo: 'bar'});
+    });
+
+  });
+
   it('emits tokens', () => {
     let currentToken = 'nothing';
     auth.token.subscribe((token) => { currentToken = token; });
+    auth.setToken('nothing');
     expect(currentToken).toEqual('nothing');
     auth.setToken(undefined);
     expect(currentToken).toBeNull();

--- a/src/lib/src/auth/auth.service.ts
+++ b/src/lib/src/auth/auth.service.ts
@@ -54,8 +54,12 @@ export class AuthService {
     if (tokStr === AuthService.AUTHORIZATION_DENIED) return false;
 
     // https://stackoverflow.com/questions/38552003/how-to-decode-jwt-token-in-javascript
-    var base64decoded = tokStr.replace(/-/g, '+').replace(/_/g, '/');
-    switch (base64decoded.length % 4) {
+    let base64decoded = tokStr.replace(/-/g, '+').replace(/_/g, '/');
+    let payload = base64decoded.split('.')[1];
+    if (!payload) {
+      throw new Error('Invalid xxxx.yyyy token string structure');
+    }
+    switch (payload.length % 4) {
       case 0:
         break;
       case 2:
@@ -65,9 +69,9 @@ export class AuthService {
         base64decoded += '=';
         break;
       default:
-        throw 'Illegal base64url string!';
+        throw new Error('Illegal base64url string!');
     }
-    return JSON.parse(atob(base64decoded.split('.')[1]));
+    return JSON.parse(atob(payload));
   }
 
   private getNonce(): string {

--- a/src/lib/src/auth/auth.service.ts
+++ b/src/lib/src/auth/auth.service.ts
@@ -23,7 +23,7 @@ export class AuthService {
       url = url.match(/\.org|\.tech/) ? `https://${url}` : `http://${url}`;
     }
     let nonce = this.getNonce();
-    return `${url}&nonce=${nonce}&response_type=token&prompt=${prompt}`;
+    return `${url}&nonce=${nonce}&response_type=token&scope=apps&prompt=${prompt}`;
   }
 
   setToken(authToken: string) {

--- a/src/lib/src/auth/auth.service.ts
+++ b/src/lib/src/auth/auth.service.ts
@@ -12,6 +12,8 @@ export class AuthService {
   token = new ReplaySubject<string>(1);
   refresh = new ReplaySubject<boolean>(1);
 
+  static AUTHORIZATION_DENIED = 'AUTHORIZATION_DENIED';
+
   config(authHost: string, authClient: string) {
     this.authHost = authHost;
     this.authClient = authClient;
@@ -42,6 +44,30 @@ export class AuthService {
   refreshToken(): Observable<string> {
     this.refresh.next(true);
     return this.token.skip(1);
+  }
+
+  failAuthorization() {
+    this.setToken(AuthService.AUTHORIZATION_DENIED);
+  }
+
+  parseToken(tokStr: string) {
+    if (tokStr === AuthService.AUTHORIZATION_DENIED) return false;
+
+    // https://stackoverflow.com/questions/38552003/how-to-decode-jwt-token-in-javascript
+    var base64decoded = tokStr.replace(/-/g, '+').replace(/_/g, '/');
+    switch (base64decoded.length % 4) {
+      case 0:
+        break;
+      case 2:
+        base64decoded += '==';
+        break;
+      case 3:
+        base64decoded += '=';
+        break;
+      default:
+        throw 'Illegal base64url string!';
+    }
+    return JSON.parse(atob(base64decoded.split('.')[1]));
   }
 
   private getNonce(): string {

--- a/src/lib/src/auth/userinfo.service.ts
+++ b/src/lib/src/auth/userinfo.service.ts
@@ -24,7 +24,6 @@ export class UserinfoService {
 
   getUserinfo(): Observable<Userinfo[]> {
     let url = `${this.authHost}/userinfo?scope=profile+apps`;
-    console.log('userinfo url:', url);
     let optionsArgs:RequestOptionsArgs = { withCredentials: true };
     let options = new RequestOptions(optionsArgs);
     return this.http.get(url, options)

--- a/src/lib/src/auth/userinfo.service.ts
+++ b/src/lib/src/auth/userinfo.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Headers, Http, RequestOptionsArgs, RequestOptions } from '@angular/http';
+import { HalDoc } from '../hal/doc/haldoc';
+import { HalObservable } from '../hal/doc/halobservable';
+import { HalService } from '../hal/hal.service';
 
 export class Userinfo {
   sub: number;
@@ -9,14 +12,16 @@ export class Userinfo {
   family_name: string;
   preferred_username: string;
   apps: any;
+  href: string;
 }
 
 @Injectable()
 export class UserinfoService {
 
   authHost: string;
+  userinfo: Userinfo;
 
-  constructor(private http: Http) { }
+  constructor(private http: Http, private hal: HalService) { }
 
   config(authHost: string) {
     this.authHost = authHost;
@@ -29,6 +34,11 @@ export class UserinfoService {
     return this.http.get(url, options)
                     .map(response => response.json() as Userinfo)
                     .catch(this.handleError);
+  }
+
+  getUserDoc(userinfo: Userinfo): HalObservable<HalDoc> {
+    let url = userinfo.href.match(/^(https?:\/\/.+?)(\/.+)/);
+    return this.hal.public(url[1], url[2]);
   }
 
   private handleError(error: any): Promise<any> {

--- a/src/lib/src/auth/userinfo.service.ts
+++ b/src/lib/src/auth/userinfo.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { Headers, Http, RequestOptionsArgs, RequestOptions } from '@angular/http';
+
+export class Userinfo {
+  sub: number;
+  name: string;
+  given_name: string;
+  family_name: string;
+  preferred_username: string;
+  apps: any;
+}
+
+@Injectable()
+export class UserinfoService {
+
+  authHost: string;
+
+  constructor(private http: Http) { }
+
+  config(authHost: string) {
+    this.authHost = authHost;
+  }
+
+  getUserinfo(): Observable<Userinfo[]> {
+    let url = `${this.authHost}/userinfo?scope=profile+apps`;
+    console.log('userinfo url:', url);
+    let optionsArgs:RequestOptionsArgs = { withCredentials: true };
+    let options = new RequestOptions(optionsArgs);
+    return this.http.get(url, options)
+                    .map(response => response.json() as Userinfo[])
+                    .catch(this.handleError);
+  }
+
+  private handleError(error: any): Promise<any> {
+    console.error('userinfo error:', error);
+    return Promise.reject(error.message || error);
+  }
+
+}

--- a/src/lib/src/auth/userinfo.service.ts
+++ b/src/lib/src/auth/userinfo.service.ts
@@ -22,12 +22,12 @@ export class UserinfoService {
     this.authHost = authHost;
   }
 
-  getUserinfo(): Observable<Userinfo[]> {
+  getUserinfo(): Observable<Userinfo> {
     let url = `${this.authHost}/userinfo?scope=profile+apps`;
     let optionsArgs:RequestOptionsArgs = { withCredentials: true };
     let options = new RequestOptions(optionsArgs);
     return this.http.get(url, options)
-                    .map(response => response.json() as Userinfo[])
+                    .map(response => response.json() as Userinfo)
                     .catch(this.handleError);
   }
 

--- a/src/lib/src/guard/auth.guard.spec.ts
+++ b/src/lib/src/guard/auth.guard.spec.ts
@@ -2,7 +2,11 @@ import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { AuthGuard } from './auth.guard';
 
 const mockAuthService = {
-  token: new ReplaySubject<string>(1)
+  token: new ReplaySubject<string>(1),
+  parseToken: (tokStr: string) => {
+    if (tokStr == 'AUTHORIZATION_DENIED') return false;
+    return tokStr;
+  }
 };
 const mockRouter = {
   goto: <any> null,
@@ -25,6 +29,20 @@ describe('AuthGuard', () => {
       expect(canActivate).toBeUndefined();
       mockAuthService.token.next('something');
       expect(canActivate).toEqual(true);
+    });
+
+  });
+
+  describe('with a token of AUTHORIZATION_DENIED', () => {
+
+    it('auth redirects to permission-denied', () => {
+      let guard = new AuthGuard(<any> mockAuthService, <any> mockRouter);
+      let canActivate: boolean;
+      guard.canActivate().subscribe((can: boolean) => { canActivate = can; });
+      expect(canActivate).toBeUndefined();
+      mockAuthService.token.next('AUTHORIZATION_DENIED');
+      expect(canActivate).toEqual(false);
+      expect(mockRouter.goto).toEqual('/permission-denied');
     });
 
   });

--- a/src/lib/src/guard/auth.guard.ts
+++ b/src/lib/src/guard/auth.guard.ts
@@ -11,7 +11,12 @@ export class AuthGuard implements CanActivate {
   canActivate(): Observable<boolean> {
     return this.authService.token.map((token) => {
       if (token) {
-        return true;
+        if (token === 'AUTHORIZATION_FAIL') {
+          this.router.navigate(['/permission-denied']);
+          return false;
+        } else {
+          return true;
+        }
       } else {
         this.router.navigate(['/login']);
         return false;

--- a/src/lib/src/guard/auth.guard.ts
+++ b/src/lib/src/guard/auth.guard.ts
@@ -11,7 +11,7 @@ export class AuthGuard implements CanActivate {
   canActivate(): Observable<boolean> {
     return this.authService.token.map((token) => {
       if (token) {
-        if (token === 'AUTHORIZATION_FAIL') {
+        if (!this.authService.parseToken(token)) {
           this.router.navigate(['/permission-denied']);
           return false;
         } else {

--- a/src/lib/src/guard/unauth.guard.spec.ts
+++ b/src/lib/src/guard/unauth.guard.spec.ts
@@ -2,7 +2,11 @@ import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { UnauthGuard } from './unauth.guard';
 
 const mockAuthService = {
-  token: new ReplaySubject<string>(1)
+  token: new ReplaySubject<string>(1),
+  parseToken: (tokStr: string) => {
+    if (tokStr == 'AUTHORIZATION_DENIED') return false;
+    return tokStr;
+  }
 };
 const mockRouter = {
   goto: <any> null,
@@ -25,6 +29,20 @@ describe('UnauthGuard', () => {
       expect(canActivate).toBeUndefined();
       mockAuthService.token.next('something');
       expect(canActivate).toEqual(false);
+    });
+
+  });
+
+  describe('with a token of AUTHORIZATION_DENIED', () => {
+
+    it('auth redirects to permission-denied', () => {
+      let unguard = new UnauthGuard(<any> mockAuthService, <any> mockRouter);
+      let canActivate: boolean;
+      unguard.canActivate().subscribe((can: boolean) => { canActivate = can; });
+      expect(canActivate).toBeUndefined();
+      mockAuthService.token.next('AUTHORIZATION_DENIED');
+      expect(canActivate).toEqual(true);
+      expect(mockRouter.goto).toEqual('/permission-denied');
     });
 
   });

--- a/src/lib/src/guard/unauth.guard.ts
+++ b/src/lib/src/guard/unauth.guard.ts
@@ -11,7 +11,7 @@ export class UnauthGuard implements CanActivate {
   canActivate(): Observable<boolean> {
     return this.authService.token.map((token) => {
       if (token) {
-        if (token === 'AUTHORIZATION_FAIL') {
+        if (!this.authService.parseToken(token)) {
           this.router.navigate(['/permission-denied']);
           return true;
         } else {

--- a/src/lib/src/guard/unauth.guard.ts
+++ b/src/lib/src/guard/unauth.guard.ts
@@ -11,8 +11,13 @@ export class UnauthGuard implements CanActivate {
   canActivate(): Observable<boolean> {
     return this.authService.token.map((token) => {
       if (token) {
-        this.router.navigate(['/']);
-        return false;
+        if (token === 'AUTHORIZATION_FAIL') {
+          this.router.navigate(['/permission-denied']);
+          return true;
+        } else {
+          this.router.navigate(['/']);
+          return false;
+        }
       } else {
         return true;
       }

--- a/src/lib/src/header/navuser.component.css
+++ b/src/lib/src/header/navuser.component.css
@@ -15,6 +15,35 @@
   display: inline-block;
   margin-top: 10px;
 }
+.nav-userinfo-menu-apps {
+  background-color: #fff;
+  border: 1px solid #f59f51;
+  padding: 0;
+  display: none;
+  min-width: 200px;
+  right: 0;
+  padding: 10px 20px;
+  position: absolute;
+  top: 100%;
+  z-index: 20;
+}
+.nav-userinfo-menu-apps .nav-userinfo-apps {
+  padding: 0;
+}
+.nav-userinfo-menu-apps .nav-userinfo-apps li a {
+  display: block;
+  font-weight: normal;
+  padding: 5px;
+  color: #368aa2;
+  height: auto;
+  line-height: 24px;
+}
+.nav-userinfo-menu-apps .nav-userinfo-apps li a:hover {
+  background-color: #eee;
+}
+.nav-userinfo:hover .nav-userinfo-menu-apps {
+  display: block;
+}
 @media screen and (min-width: 768px) {
   .name {
     display: inline-block;

--- a/src/lib/src/header/navuser.component.spec.ts
+++ b/src/lib/src/header/navuser.component.spec.ts
@@ -2,16 +2,17 @@ import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { By }              from '@angular/platform-browser';
 import { Component, DebugElement }    from '@angular/core';
 import { NavUserComponent } from './navuser.component';
+import { Userinfo } from '../auth/userinfo.service';
 
 @Component({
   selector: 'test-component',
-  template: `<prx-navuser [userName]="userName">
+  template: `<prx-navuser [userinfo]="userinfo">
         <h1 class="user-loading">IsLoading</h1>
         <h1 class="user-loaded">IsLoaded</h1>
       </prx-navuser>`
 })
 class TestComponent {
-  userName: string;
+  userinfo: Userinfo;
 }
 
 describe('Component: NavUserComponent', () => {
@@ -34,13 +35,15 @@ describe('Component: NavUserComponent', () => {
   }));
 
   it('displays the account name', () => {
-    comp.userName = 'Mary';
+    comp.userinfo = new Userinfo();
+    comp.userinfo.preferred_username = 'Mary';
     fix.detectChanges();
     expect(de.query(By.css('.name')).nativeElement.innerText).toEqual('Mary');
   });
 
   it('displays the loaded content', () => {
-    comp.userName = 'Mary';
+    comp.userinfo = new Userinfo();
+    comp.userinfo.preferred_username = 'Mary';
     fix.detectChanges();
     expect(el.innerText).toContain('IsLoaded');
   });

--- a/src/lib/src/header/navuser.component.ts
+++ b/src/lib/src/header/navuser.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import { Userinfo } from '../auth/userinfo.service';
 
 @Component({
   moduleId: module.id,
@@ -8,14 +9,22 @@ import { Component, Input } from '@angular/core';
     './navuser.component.css'
   ],
   template: `
-    <div class="nav-holder">
-      <ng-template [ngIf]="userName">
-        <a *ngIf="userName">
-          <span class="name">{{userName}}</span>
+    <div class="nav-holder nav-userinfo">
+      <ng-template [ngIf]="userinfo">
+        <a *ngIf="userinfo">
+          <span class="name">{{userinfo.preferred_username}}</span>
           <ng-content select=".user-loaded"></ng-content>
         </a>
+        <div *ngIf="userinfo" class="nav-userinfo-menu-apps">
+          <ul class="nav-userinfo-apps">
+            <li><a class="nav-userinfo-app" href="https://exchange.prx.org/">PRX Exchange</a></li>
+            <li *ngFor="let appName of appNames();">
+              <a class="nav-userinfo-app" href="{{userinfo.apps[appName]}}">{{appLabel(appName)}}</a>
+            </li>
+          </ul>
+        </div>
       </ng-template>
-      <div *ngIf="!userName" class="spin-holder">
+      <div *ngIf="!userinfo" class="spin-holder">
         <ng-content select=".user-loading"></ng-content>
       </div>
     </div>
@@ -23,5 +32,18 @@ import { Component, Input } from '@angular/core';
 })
 
 export class NavUserComponent {
-  @Input() userName: string;
+  @Input() userinfo: Userinfo;
+
+  appLabel(appName: string): string {
+    let n = appName.replace(/^https?:\/\//, '').replace(/\..+/, '');
+    return 'PRX ' + n.charAt(0).toUpperCase() + n.slice(1);
+  }
+
+  appNames(): any[] {
+    let names = new Array();
+    for (let appName in this.userinfo.apps) {
+      names.push(appName);
+    }
+    return names;
+  }
 }


### PR DESCRIPTION
The current AuthService has a binary logic: keep asking for a token from the ID service until we get one.

We want to introduce a 3rd possibility beyond a token yes|no: that a token request has failed with a specific error (`invalid_scope`) and there will never be a valid token forthcoming, because the problem is with authorization scope, not with the user's authentication credentials.

This approach relies on a reserved special token string `AUTHORIZATION_DENIED `.

Depends upon https://github.com/PRX/id.prx.org/pull/61