### PR TITLE
fix chart max ticks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "PRX Angular 2 style guide library",
   "keywords": [
     "PRX",

--- a/src/demo/app/charts/charts-timeseries-demo.component.ts
+++ b/src/demo/app/charts/charts-timeseries-demo.component.ts
@@ -74,6 +74,11 @@ import * as moment from 'moment';
           <code>@Input() paddingRight = 30</code>
           - defaults to 30px, sets the <a href="http://c3js.org/reference.html#padding-right">padding on the right of the chart</a>
         </li>
+        <li>
+          <code>@Input() maxTicks</code>
+          - not set by default.
+          Doesn't always play well with tick labels on timeseries charts so use sparingly for charts with a lot of datapoints.
+        </li>
       </ul>
       
       <aside>

--- a/src/lib/src/charts/timeseries-chart.component.ts
+++ b/src/lib/src/charts/timeseries-chart.component.ts
@@ -113,6 +113,13 @@ export class TimeseriesChartComponent implements OnChanges {
             count: this.maxTicks
           }
         };
+        if (this.type === 'bar') {
+          config['bar'] = {
+            width: {
+              ratio: this.maxTicks / this.datasets[0].data.length
+            }
+          };
+        }
       }
 
       if (this.formatY) {

--- a/src/lib/src/charts/timeseries-chart.component.ts
+++ b/src/lib/src/charts/timeseries-chart.component.ts
@@ -25,6 +25,7 @@ export class TimeseriesChartComponent implements OnChanges {
   @Input() pointRadius = 3.25;
   @Input() pointRadiusOnHover = 3.75;
   @Input() paddingRight = 30;
+  @Input() maxTicks: number;
 
   chart: any;
   @ViewChild('chart') el: ElementRef;
@@ -81,14 +82,6 @@ export class TimeseriesChartComponent implements OnChanges {
         padding: {
           right: this.paddingRight
         },
-        axis: {
-          x: {
-            tick: {
-              fit: false,
-              count: Math.min(20, this.datasets[0].data.length)
-            }
-          }
-        },
         bindto: this.el.nativeElement
       };
 
@@ -97,29 +90,51 @@ export class TimeseriesChartComponent implements OnChanges {
       }
 
       if (this.formatX) {
-        config.axis.x['type'] = 'timeseries';
-        config.axis.x.tick['format'] = this.formatX;
+        config['axis'] = {
+          ...config['axis']
+        };
+        config['axis']['x'] = {
+          ...config['axis']['x'],
+          type: 'timeseries',
+          tick: {
+            format: this.formatX
+          }
+        };
+      }
+      // limit the max number of ticks, which honestly doesn't always work well with timeseries tick labels
+      if (this.maxTicks && this.datasets[0].data.length > this.maxTicks) {
+        config['axis'] = {
+          ...config['axis']
+        };
+        config['axis']['x'] = {
+          ...config['axis']['x'],
+          tick: {
+            ...config['axis']['x']['tick'],
+            count: this.maxTicks
+          }
+        };
       }
 
       if (this.formatY) {
         config['axis'] = {
-          ...config.axis,
-          y: {
-            tick: {
-              format: this.formatY
-            }
+          ...config['axis']
+        };
+        config['axis']['y'] = {
+          ...config['axis']['y'],
+          tick: {
+            format: this.formatY
           }
         };
       }
 
       if (this.minY !== undefined) {
         config['axis'] = {
-          ...config['axis'],
-          y: {
-            ...config['axis']['y'],
-            min: this.minY,
-            padding: {top: 20, bottom: 20}
-          }
+          ...config['axis']
+        };
+        config['axis']['y'] = {
+          ...config['axis']['y'],
+          min: this.minY,
+          padding: {top: 20, bottom: 20}
         };
       }
 
@@ -127,7 +142,7 @@ export class TimeseriesChartComponent implements OnChanges {
 
       if (this.strokeWidth && this.type === 'line') {
         // dynamically add style with the equivalence of a deep selector, not sure of a better way
-        var collection: HTMLCollection = this.el.nativeElement.getElementsByClassName('c3-line');
+        const collection: HTMLCollection = this.el.nativeElement.getElementsByClassName('c3-line');
         // HTMLCollection is an Array like object but not an Array
         Array.prototype.forEach.call(collection, (element: HTMLElement) => element.style['stroke-width'] = this.strokeWidth + 'px');
       }

--- a/src/lib/src/charts/timeseries-chart.component.ts
+++ b/src/lib/src/charts/timeseries-chart.component.ts
@@ -80,12 +80,9 @@ export class TimeseriesChartComponent implements OnChanges {
         config.data['groups'] = [this.groups];
       }
 
+      const axis: {x?: any, y?: any} = {};
       if (this.formatX) {
-        config['axis'] = {
-          ...config['axis']
-        };
-        config['axis']['x'] = {
-          ...config['axis']['x'],
+        axis.x = {
           type: 'timeseries',
           tick: {
             format: this.formatX
@@ -94,13 +91,10 @@ export class TimeseriesChartComponent implements OnChanges {
       }
       // limit the max number of ticks, which honestly doesn't always work well with timeseries tick labels
       if (this.maxTicks && this.datasets[0].data.length > this.maxTicks) {
-        config['axis'] = {
-          ...config['axis']
-        };
-        config['axis']['x'] = {
-          ...config['axis']['x'],
+        axis.x = {
+          ...axis.x,
           tick: {
-            ...config['axis']['x']['tick'],
+            ...axis.x['tick'],
             count: this.maxTicks
           }
         };
@@ -114,11 +108,7 @@ export class TimeseriesChartComponent implements OnChanges {
       }
 
       if (this.formatY) {
-        config['axis'] = {
-          ...config['axis']
-        };
-        config['axis']['y'] = {
-          ...config['axis']['y'],
+        axis.y = {
           tick: {
             format: this.formatY
           }
@@ -126,14 +116,15 @@ export class TimeseriesChartComponent implements OnChanges {
       }
 
       if (this.minY !== undefined) {
-        config['axis'] = {
-          ...config['axis']
-        };
-        config['axis']['y'] = {
-          ...config['axis']['y'],
+        axis.y = {
+          ...axis.y,
           min: this.minY,
           padding: {top: 20, bottom: 20}
         };
+      }
+
+      if (axis.x || axis.y) {
+        config['axis'] = axis;
       }
 
       if (this.type === 'line' || this.type === 'area') {

--- a/src/lib/src/charts/timeseries-chart.component.ts
+++ b/src/lib/src/charts/timeseries-chart.component.ts
@@ -67,15 +67,6 @@ export class TimeseriesChartComponent implements OnChanges {
         legend: {
           show: false
         },
-        point: {
-          show: this.showPoints,
-          r: this.pointRadius,
-          focus: {
-            expand: {
-              r: this.pointRadiusOnHover
-            }
-          }
-        },
         color: {
           pattern: this.colors
         },
@@ -142,6 +133,18 @@ export class TimeseriesChartComponent implements OnChanges {
           ...config['axis']['y'],
           min: this.minY,
           padding: {top: 20, bottom: 20}
+        };
+      }
+
+      if (this.type === 'line' || this.type === 'area') {
+        config['point'] = {
+          show: this.showPoints,
+          r: this.pointRadius,
+          focus: {
+            expand: {
+              r: this.pointRadiusOnHover
+            }
+          }
         };
       }
 


### PR DESCRIPTION
Fixes
[metrics #307](https://github.com/PRX/metrics.prx.org/issues/307)
[metrics #298](https://github.com/PRX/metrics.prx.org/issues/298)

a small adjustment to the chart config to only set the [x axis tick count](https://c3js.org/reference.html#axis-x-tick-count) when there are specifically WAY too many datapoints to lay the ticks out with the default settings according to the timeseries datapoints.

I also removed the [fit](https://c3js.org/reference.html#axis-x-tick-fit) setting as it reads that setting it to false will position the ticks according to their datapoints, but it didn't solve the issue.