### PR TITLE
UMD build is in a subdirectory named bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/prx/styleguide.prx.org/issues",
     "email": "help@prx.org"
   },
-  "main": "./ngx-prx-styleguide.umd.js",
+  "main": "./bundles/ngx-prx-styleguide.umd.js",
   "module": "./ngx-prx-styleguide.es5.js",
   "es2015": "./ngx-prx-styleguide.js",
   "typings": "./ngx-prx-styleguide.d.ts",


### PR DESCRIPTION
Edited `package.json` to reflect reality. I guess the Angular build uses the `module` field by default.

Quite similar to a certain commit in another repo: filipesilva/angular-quickstart-lib@d1b6c0a7