### PR TITLE
Reflect date input change in model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "description": "PRX Angular 6 style guide library",
   "keywords": [
     "PRX",

--- a/projects/ngx-prx-styleguide/package.json
+++ b/projects/ngx-prx-styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "description": "PRX Angular 2 style guide library",
   "keywords": [
     "PRX",

--- a/projects/ngx-prx-styleguide/src/lib/model/base.model.spec.ts
+++ b/projects/ngx-prx-styleguide/src/lib/model/base.model.spec.ts
@@ -325,6 +325,18 @@ describe('BaseModel', () => {
       expect(base.changed('one')).toBeFalsy();
     });
 
+    it('can compare date fields', () => {
+      const originalDate = new Date();
+      const clonedDate = new Date(originalDate.getTime());
+      const newDate = new Date(originalDate.getTime() - 24 * 60 * 60 * 1000);
+      base.SETABLE = ['one'];
+      base.original = {one: originalDate};
+      base.set('one', clonedDate);
+      expect(base.changed('one')).toBeFalsy();
+      base.set('one', newDate);
+      expect(base.changed('one')).toBeTruthy();
+    });
+
     it('cascades to child relations', () => {
       base.RELATIONS = ['foo'];
       expect(base.changed('foo')).toBeFalsy();

--- a/projects/ngx-prx-styleguide/src/lib/model/base.model.ts
+++ b/projects/ngx-prx-styleguide/src/lib/model/base.model.ts
@@ -242,6 +242,8 @@ export abstract class BaseModel {
       } else if (this.original[f] instanceof Array && this[f] instanceof Array) {
         let a1 = this.original[f], a2 = this[f];
         return a1.length !== a2.length || a1.some((val: any, idx: number) => val !== a2[idx]);
+      } else if (this.original[f] instanceof Date && this[f] instanceof Date) {
+        return this.original[f].getTime() !== this[f].getTime();
       } else {
         return this.original[f] !== this[f];
       }

--- a/projects/ngx-prx-styleguide/src/lib/tz-datepicker/tz-datepicker.component.spec.ts
+++ b/projects/ngx-prx-styleguide/src/lib/tz-datepicker/tz-datepicker.component.spec.ts
@@ -59,7 +59,7 @@ describe('TzDatepickerComponent', () => {
   });
 
   it('Initializes the date model correctly', () => {
-    const newDateModel = component.tzDateModelInit();
+    const newDateModel = component.modelFromDate(testDate);
     expect(newDateModel.pickerDate).toEqual(testDate);
     expect(newDateModel.tz).toEqual(testTz);
     // 2:00AM UTC === 10PM EST
@@ -69,7 +69,7 @@ describe('TzDatepickerComponent', () => {
 
   it('Initializes the time for browsers with no time support', () => {
     component.supportsTimeInput = false;
-    const newDateModel = component.tzDateModelInit();
+    const newDateModel = component.modelFromDate(testDate);
     // 2:00AM UTC === 10PM EST
     expect(newDateModel.time).toEqual('10:00:00');
     expect(newDateModel.meridiem).toEqual('PM');
@@ -123,5 +123,17 @@ describe('TzDatepickerComponent', () => {
       .seconds(sec)
       .toDate();
     expect(dateChangeStub).toHaveBeenCalledWith(expectedDate);
+  });
+
+  it(`Updates the model when date is set`, () => {
+    const newTestDate = new Date(testDate.getTime() + 24 * 60 * 60 * 1000)
+    const modelSetSpy = jest.spyOn(component, 'modelFromDate')
+    expect(modelSetSpy).not.toHaveBeenCalled();
+    expect(component.model.finalDate.getTime()).toBe(testDate.getTime());
+    component.date = newTestDate;
+    expect(modelSetSpy).toHaveBeenCalledTimes(1);
+    expect(modelSetSpy).toHaveBeenCalledWith(newTestDate);
+    expect(component.model.finalDate.getTime()).toBe(newTestDate.getTime());
+    expect(dateChangeStub).not.toHaveBeenCalled();
   });
 });

--- a/projects/ngx-prx-styleguide/src/lib/tz-datepicker/tz-datepicker.component.ts
+++ b/projects/ngx-prx-styleguide/src/lib/tz-datepicker/tz-datepicker.component.ts
@@ -73,6 +73,9 @@ export class TzDatepickerComponent implements OnInit {
   @Input()
   set date(value: Date) {
     this._date = value;
+    if(this.model) {
+      this.model = this.modelFromDate(value);
+    }
   }
   get date() {
     return this.model && this.model.finalDate ? this.model.finalDate : this._date;
@@ -116,22 +119,20 @@ export class TzDatepickerComponent implements OnInit {
         publishReplay(1),
         refCount()
       )
-      
-      .pipe(share());
     this.timezones.subscribe({
       error: err => console.error('Timezone data failed to load: ' + err),
       complete: () => {
-        this.model = this.tzDateModelInit();
+        this.model = this.modelFromDate(this.date);
       }
     });
   }
 
-  tzDateModelInit() {
-    const userTimezone = moment.tz.guess();
-    const momentDate = moment.tz(this.date, userTimezone);
+  modelFromDate(date) {
+    const timezone = this.model && this.model.tz ? this.model.tz : moment.tz.guess();
+    const momentDate = moment.tz(date, timezone);
     const timeString = this.supportsTimeInput ? momentDate.format('HH:mm:ss') : momentDate.format('hh:mm:ss');
     const meridiem = this.supportsTimeInput ? null : momentDate.format('A');
-    return new TzDate(momentDate.toDate(), timeString, userTimezone, meridiem);
+    return new TzDate(momentDate.toDate(), timeString, timezone, meridiem);
   }
 
   handleChange() {
@@ -149,9 +150,5 @@ export class TzDatepickerComponent implements OnInit {
     input.setAttribute('value', notADateValue);
 
     return input.value !== notADateValue;
-  }
-
-  get diagnostic() {
-    return JSON.stringify(this.model);
   }
 }


### PR DESCRIPTION
Also removes some cruft and allows comparison of dates on the base model without requiring they be the same instance of `Date`