### PR TITLE
Update layout and header CSS

### DIFF
--- a/projects/ngx-prx-styleguide/src/assets/styles/_layout.scss
+++ b/projects/ngx-prx-styleguide/src/assets/styles/_layout.scss
@@ -29,14 +29,12 @@ main {
   display: block;/* IE 11 gives auto/no height to main */
   min-height: 200px;
   background: $white-smoke;
-  padding-top: 50px;
   padding-bottom: $padding-base;
   position: relative;
 }
 @media screen and (min-width: 768px) {
   main {
     min-height: 400px;
-    padding-top: 73px;
   }
 }
 
@@ -52,10 +50,6 @@ article .main > section {
     padding-right: 30px;
     padding-left: 30px;
   }
-}
-
-article .main > section {
-  position: relative;
 }
 
 /* Looks like this should be in a .content container with display: flex but Publish is not using */

--- a/projects/ngx-prx-styleguide/src/lib/header/header.component.css
+++ b/projects/ngx-prx-styleguide/src/lib/header/header.component.css
@@ -2,13 +2,7 @@
  * PRX header component
  */
 :host {
-  --header-height: 50px;
-  --logo-width: 72px;
-
-  position: fixed;
-  top: 0;
-  right: 0;
-  left: 0;
+  display: block;
   max-width: 1200px;
   margin: 0 auto;
   z-index: 900;


### PR DESCRIPTION
Small tweaks to layout and header CSS to accommodate use of prxSticky directive to handle sticky elements.

Removes fixed positioning from header CSS. prxSticky directive will set it to sticky.

Removes top padding and positioning from .main and section elements. Sticky elements are still considered inline, so we mo longer have to account for the height for a fixed header.