### PR TITLE
AOT-compatible approach to "re-opening" class

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ npm publish dist/ngx-prx-styleguide
 ```
 
 After the package has been published, push the npm generated commit and tag to
-the repository: 
+the repository:
 ```
 git push --follow-tags
 ```

--- a/projects/ngx-prx-styleguide/src/lib/upload/model/audio-version.model.ts
+++ b/projects/ngx-prx-styleguide/src/lib/upload/model/audio-version.model.ts
@@ -1,8 +1,8 @@
-import {forkJoin as observableForkJoin, Observable } from 'rxjs';
-import {finalize, map} from 'rxjs/operators';
+import { forkJoin as observableForkJoin, Observable } from 'rxjs';
+import { finalize, map } from 'rxjs/operators';
 import { AudioFileModel } from './audio-file.model';
 import { VERSION_TEMPLATED, LENGTH, REQUIRED} from './invalid';
-import { HasUpload, applyMixins } from './upload';
+import { HasUpload, createGetUploads, createSetUploads } from './upload';
 import { HalDoc } from '../../hal/doc/haldoc';
 import { Upload } from '../service';
 import { BaseModel } from '../../model/base.model';
@@ -34,8 +34,12 @@ export class AudioVersionModel extends BaseModel implements HasUpload {
 
   // HasUpload mixin
   hasUploadMap: string;
-  getUploads: (rel: string) => Observable<(HalDoc|string)[]>;
-  setUploads: (rel: string, uuids?: string[]) => void;
+  get getUploads() {
+    return createGetUploads();
+  }
+  get setUploads() {
+    return createSetUploads();
+  }
 
   getContentType() {
     if (this.template && this.template.hasOwnProperty('contentType')) {
@@ -86,7 +90,7 @@ export class AudioVersionModel extends BaseModel implements HasUpload {
   related() {
     const fileSort = (f1, f2) => f1.position - f2.position;
 
-    let files = this.getUploads('prx:audio').pipe(map(audios => {
+    let files = this.getUploads('prx:audio').pipe(map((audios: HalDoc[]) => {
       const docs = audios.map(docOrUuid => new AudioFileModel(this.template, this.doc, docOrUuid));
       this.setUploads('prx:audio', docs.map(d => d.uuid));
       return docs.sort(fileSort);
@@ -268,5 +272,3 @@ export class AudioVersionModel extends BaseModel implements HasUpload {
   }
 
 }
-
-applyMixins(AudioVersionModel, [HasUpload]);

--- a/projects/ngx-prx-styleguide/src/lib/upload/model/upload/has-upload.mixin.spec.ts
+++ b/projects/ngx-prx-styleguide/src/lib/upload/model/upload/has-upload.mixin.spec.ts
@@ -1,5 +1,4 @@
-import { Observable } from 'rxjs';
-import { HasUpload, applyMixins } from './has-upload.mixin';
+import { HasUpload, createGetUploads, createSetUploads } from './has-upload.mixin';
 import { MockHalService } from '../../../hal/mock/mock-hal.service';
 
 const cms = new MockHalService();
@@ -8,13 +7,16 @@ describe('HasUpload', () => {
 
   class ItHasAnUpload implements HasUpload {
     hasUploadMap: string;
-    getUploads: (rel: string) => Observable<any[]>;
-    setUploads: (rel: string, uuids?: string[]) => void;
+    get getUploads() {
+      return createGetUploads();
+    }
+    get setUploads() {
+      return createSetUploads();
+    }
     // tslint:disable-next-line:no-shadowed-variable
     constructor(public doc, public SETABLE = []) {}
     set(fld, val) { this[fld] = val; }
   }
-  applyMixins(ItHasAnUpload, [HasUpload]);
 
   let doc, has;
   beforeEach(() => {

--- a/projects/ngx-prx-styleguide/src/public_api.ts
+++ b/projects/ngx-prx-styleguide/src/public_api.ts
@@ -68,5 +68,5 @@ export { UploadModule } from './lib/upload/upload.module';
 export { PlayerService } from './lib/audio';
 export { MimeTypeService, UploadService, Upload } from './lib/upload/service';
 export { AudioFileModel, AudioVersionModel, AudioVersionTemplateModel, AudioFileTemplateModel } from './lib/upload/model';
-export { UploadableModel, HasUpload, applyMixins } from './lib/upload/model/upload';
+export { UploadableModel, HasUpload, createGetUploads, createSetUploads } from './lib/upload/model/upload';
 export { DurationPipe, FileSelectDirective, FileSizePipe } from './lib/upload/file';


### PR DESCRIPTION
This new approach uses a higher-order function to return the function we want to execute when `getUploads` and `setUploads` are called, and then defines those functions using a getter in the class that calls the higher-order function that returns the function we want to execute. This approach forces the resolution of that code path to be delayed until runtime, while ensuring that the function executes within the scope of the class instance we expect. Note that this approach could break if the AOT compiler tries to get smarter in the future.

Here's what the AOT build gave us with the previous approach:
```javascript
// Definition of AudioVersionModel
nn = function(e) {
  function t(t) {
      var n = e.call(this) || this;
      return n.explicit = "",
      n.SETABLE = ["label", "explicit", "hasUploadMap"]
      // Other constructor logic
  }
  return Object(a.__extends)(t, e),
  t.prototype.getContentType = function() {
      return this.template && this.template.hasOwnProperty("contentType") ? this.template.contentType : null
  }
  // Other class methods
}

// ⚠️ Unrelated closure ⚠️
$t = function() {
  function e() {}
  return e.prototype.getUploads = function(e) {
      this.SETABLE.indexOf("hasUploadMap") < 0 && this.SETABLE.push("hasUploadMap");
      // Implementation of getUploads
  }
  ,
  e.prototype.setUploads = function(e, t) {
      this.SETABLE.indexOf("hasUploadMap") < 0 && this.SETABLE.push("hasUploadMap");
      // Implementation of setUploads
  }
  ,
  e
}()
```

Here's what the relevant AOT-compiler ES2015 output looks like now:

```javascript
// Definition of AudioVersionModel
nn = function(e) {
  function t(t) {
      var n = e.call(this) || this;
      return n.explicit = "",
      n.SETABLE = ["label", "explicit", "hasUploadMap"]
      // Other constructor logic
  }
  Object.defineProperty(t.prototype, "getUploads", {
      get: function() {
          return $t()
      },
      enumerable: !0,
      configurable: !0
  }),
  Object.defineProperty(t.prototype, "setUploads", {
      get: function() {
          return Zt()
      },
      enumerable: !0,
      configurable: !0
  }),
  t.prototype.getContentType = function() {
      return this.template && this.template.hasOwnProperty("contentType") ? this.template.contentType : null
  }
  // Other class methods
}(be)

// Definition of HasUpload mixin
function $t() {
  return function(e) {
      this.SETABLE.indexOf("hasUploadMap") < 0 && this.SETABLE.push("hasUploadMap");
      // Implementation of getUploads
  }
}
function Zt() {
  return function(e, t) {
      this.SETABLE.indexOf("hasUploadMap") < 0 && this.SETABLE.push("hasUploadMap");
      // Implementation of setUploads
  }
}
```