### PR TITLE
Prevent appending 2 auth tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "PRX Angular 6 style guide library",
   "keywords": [
     "PRX",

--- a/projects/ngx-prx-styleguide/package.json
+++ b/projects/ngx-prx-styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "PRX Angular 2 style guide library",
   "keywords": [
     "PRX",


### PR DESCRIPTION
So one thing to know... the angular `HttpHeaders` class always returns a clone of itself on append/set/delete, rather than modifying the existing object.

Somehow we were reusing the `let headers` object, and re-appending the Authorization and returning it.  (In spite of the `this.auth.token.pipe(first())` in there).  A better solution was to refactor the http headers/options to be immutable.  And it works!