### PR TITLE
Set z-index on status-bar when stuck by sticky directive

### DIFF
--- a/projects/ngx-prx-styleguide/src/assets/styles/_variables.scss
+++ b/projects/ngx-prx-styleguide/src/assets/styles/_variables.scss
@@ -5,7 +5,7 @@
 
 //== Stratas
 $strata-nav: 9999;
-$strata-overlay: $strata-nav + 1;
+$strata-overlay: $strata-nav + 10;
 $strata-modal: $strata-overlay + 1;
 $strata-background: -1;
 $strata-content: 0;

--- a/projects/ngx-prx-styleguide/src/assets/styles/_variables.scss
+++ b/projects/ngx-prx-styleguide/src/assets/styles/_variables.scss
@@ -3,6 +3,15 @@
 // Variables should follow the `$component-state-property-size` formula for
 // consistent naming. Ex: $nav-link-disabled-color and $modal-content-box-shadow-xs.
 
+//== Stratas
+$strata-nav: 9999;
+$strata-overlay: $strata-nav + 1;
+$strata-modal: $strata-overlay + 1;
+$strata-background: -1;
+$strata-content: 0;
+$strata-content-above: 1;
+$strata-content-top: 10;
+
 // Color System
 /// Greys
 $white:    #fff !default;

--- a/projects/ngx-prx-styleguide/src/lib/header/header.component.scss
+++ b/projects/ngx-prx-styleguide/src/lib/header/header.component.scss
@@ -1,13 +1,16 @@
 /*
  * PRX header component
  */
+
+ @import '../../assets/styles/theme';
+
 :host {
   display: block;
   max-width: 1200px;
   margin: 0 auto;
-  z-index: 900;
-  border-bottom: 1px solid #e6e6e6;
-  background: #1a1a1a;
+  z-index: $strata-nav;
+  border-bottom: 1px solid $grey-200;
+  background: $grey-900;
   padding-left: 20px;
 }
 

--- a/projects/ngx-prx-styleguide/src/lib/header/header.component.ts
+++ b/projects/ngx-prx-styleguide/src/lib/header/header.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'prx-header',
-  styleUrls: ['./header.component.css'],
+  styleUrls: ['./header.component.scss'],
   template: `
     <header>
       <h1><a [routerLink]="['/']">PRX</a></h1>

--- a/projects/ngx-prx-styleguide/src/lib/modal/modal.component.scss
+++ b/projects/ngx-prx-styleguide/src/lib/modal/modal.component.scss
@@ -1,19 +1,22 @@
 /*
  * Modal alert styling
  */
+
+ @import '../../assets/styles/theme';
+
 .overlay {
   position: fixed;
-  z-index: 998;
+  z-index: $strata-overlay;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: #000;
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: $black;
+  background-color: transparentize($black, 0.6);
 }
 .modal {
   position: fixed;
-  z-index: 999;
+  z-index: $strata-modal;
   display: flex;
   flex-direction: column;
   top: 50%;
@@ -25,7 +28,7 @@
   margin-left: -250px;
   min-height: 200px;
   margin-top: -100px;
-  background: #fff;
+  background: $white;
   overflow-x: auto;
   overflow-y: auto;
   padding: 15px 25px 10px;
@@ -54,12 +57,12 @@ footer button {
   margin-left: 10px;
 }
 footer button.secondary {
-  color: #777;
-  background: #fff;
+  color: $grey-700;
+  background: $white;
 }
 footer button.secondary:hover {
-  color: #fff;
-  background-color: #ff9600;
+  color: $white;
+  background-color: $orange
 }
 
 /*
@@ -80,5 +83,5 @@ section >>> ul {
   margin-left: 28px;
 }
 section >>> .error {
-  color: #e32;
+  color: $danger;
 }

--- a/projects/ngx-prx-styleguide/src/lib/modal/modal.component.scss
+++ b/projects/ngx-prx-styleguide/src/lib/modal/modal.component.scss
@@ -12,7 +12,7 @@
   right: 0;
   bottom: 0;
   background-color: $black;
-  background-color: transparentize($black, 0.6);
+  background-color: transparentize($color: $black, $amount: 0.6);
 }
 .modal {
   position: fixed;

--- a/projects/ngx-prx-styleguide/src/lib/modal/modal.component.ts
+++ b/projects/ngx-prx-styleguide/src/lib/modal/modal.component.ts
@@ -3,7 +3,7 @@ import { ModalService, ModalState } from './modal.service';
 
 @Component({
   selector: 'prx-modal',
-  styleUrls: ['modal.component.css'],
+  styleUrls: ['modal.component.scss'],
   template: `
     <div *ngIf="shown" class="overlay" (document:keydown)="onKey($event)"></div>
     <div *ngIf="shown" class="modal"

--- a/projects/ngx-prx-styleguide/src/lib/status-bar/status-bar.component.scss
+++ b/projects/ngx-prx-styleguide/src/lib/status-bar/status-bar.component.scss
@@ -22,5 +22,43 @@
     & > * + * {
       border-left: $status_bar-item-border_size solid $white-fog;
     }
+
+    prx-button {
+      position: relative;
+
+      .invalid-tip {
+        position: absolute;
+        top: calc(100% + 0.75rem);
+        right: 0.5rem;
+
+        padding: 0.5rem 0.75rem;
+
+        background-color: $warning;
+
+        color: $white;
+        white-space: nowrap;
+
+        &:before {
+          content: '';
+          display: block;
+          position: absolute;
+          bottom: 100%;
+          right: 0;
+          width: 0;
+          height: 0;
+          z-index: $strata-background;
+
+          border: 0 solid transparent;
+          border-top-width: 0.5rem;
+          border-right: 0.5rem solid $warning;
+
+          line-height: 0;
+        }
+
+        h3, h4 {
+          font-weight: bold;
+        }
+      }
+    }
   }
 }

--- a/projects/ngx-prx-styleguide/src/lib/status-bar/status-bar.component.scss
+++ b/projects/ngx-prx-styleguide/src/lib/status-bar/status-bar.component.scss
@@ -14,6 +14,10 @@
   font-size: 1rem;
   line-height: $status_bar-height;
 
+  &.js-stuck {
+    z-index: $strata-nav - 1;
+  }
+
   ::ng-deep {
     & > * + * {
       border-left: $status_bar-item-border_size solid $white-fog;

--- a/projects/ngx-prx-styleguide/src/lib/status-bar/status-bar.component.stories.ts
+++ b/projects/ngx-prx-styleguide/src/lib/status-bar/status-bar.component.stories.ts
@@ -2,14 +2,45 @@ import { storiesOf, moduleMetadata } from '@storybook/angular';
 import { StatusBarModule } from './status-bar.module';
 import { IconModule } from '../icon/icon.module';
 import { ImageModule } from '../image/image.module';
+import { FancyFormModule } from '../fancy-form/fancy-form.module';
 import { centered } from '@storybook/addon-centered/angular';
+import { BaseModel, RelatedMap } from '../model/base.model';
+import { HalDoc } from '../hal/doc/haldoc';
+import { Observable, of as ofasobservableOf } from 'rxjs';
+
+// Setup simple model for the stories.
+class SimpleModel extends BaseModel {
+  public foo: string;
+
+  constructor(parent: HalDoc, demo?: HalDoc, loadRelated = true) {
+    super();
+    this.init(parent, demo, loadRelated);
+  }
+
+  SETABLE = ['foo'];
+
+  encode(): {} { return {}; };
+  decode(): void {
+    this.foo = this.doc['foo'];
+  };
+  key(): string { return 'simple-model'; };
+  related(): RelatedMap { return {}; };
+  saveNew(data: {}): Observable<HalDoc> { return ofasobservableOf(this.doc); };
+};
+const model = new SimpleModel(null, new HalDoc({
+  foo: 'bar'
+}, null));
+
+// Force model change so examples using model will be visible. T_T
+model.set('foo', 'baz');
 
 // Module metadata for stories.
 const storiesModuleMetaData = moduleMetadata({
   imports: [
     StatusBarModule,
     IconModule,
-    ImageModule
+    ImageModule,
+    FancyFormModule
   ],
   schemas: [],
   declarations: [],
@@ -61,6 +92,51 @@ _Selector_ \`prx-status-bar\`
 \`\`\`html
 <prx-status-bar>
   <!-- Add status bar sub-components here. -->
+</prx-status-bar>
+\`\`\`
+`
+      }
+    }
+  );
+
+storiesOf('Navigation|Status Bar/Examples', module)
+  .addDecorator(centered)
+  .addDecorator(storiesModuleMetaData)
+  .add(
+    'Save Button w/ model error',
+    () => ({
+      template: `
+      <div class="main">
+        <prx-status-bar>
+          <prx-status-bar-text stretch></prx-status-bar-text>
+          <prx-button [model]="model" disabled=1 >
+            Save
+            <div class="invalid-tip">
+              <h4>Invalid changes</h4>
+              <p>Correct them before saving</p>
+            </div>
+          </prx-button>
+        </prx-status-bar>
+      </div>
+      `,
+      props: {},
+      styles: [
+        `
+        .main {
+          width: 90vw;
+        }
+        `
+      ]
+    }),
+    {
+      notes: {
+        markdown:
+`
+## Usage
+
+\`\`\`html
+<prx-status-bar>
+  <prx-button [model]="model" disabled=0 >Save</prx-button>
 </prx-status-bar>
 \`\`\`
 `

--- a/projects/ngx-prx-styleguide/src/lib/toastr/toastr.component.scss
+++ b/projects/ngx-prx-styleguide/src/lib/toastr/toastr.component.scss
@@ -1,3 +1,5 @@
+@import '../../assets/styles/theme';
+
 div {
   visibility: hidden;
   position: fixed;
@@ -5,23 +7,23 @@ div {
   margin-left: -125px;
   text-align: center;
   padding: 16px;
-  background-color: #ff9600;
-  color: #fff;
-  z-index: 9999;
+  background-color: $warning;
+  color: $white;
+  z-index: $strata-overlay - 1;
   top: 30px;
   left: 50%;
 }
 
 .info {
-  background-color: #0089bd;
+  background-color: $info;
 }
 
 .success {
-  background-color: #61A85D;
+  background-color: $success;
 }
 
 .error {
-  background-color: #ee4d3e;
+  background-color: $danger;
 }
 
 .show {

--- a/projects/ngx-prx-styleguide/src/lib/toastr/toastr.component.ts
+++ b/projects/ngx-prx-styleguide/src/lib/toastr/toastr.component.ts
@@ -3,7 +3,7 @@ import { ToastrService } from './toastr.service';
 
 @Component({
   selector: 'prx-toastr',
-  styleUrls: ['toastr.component.css'],
+  styleUrls: ['toastr.component.scss'],
   template: `
     <div [class]="status" [class.show]="shown" (document:keydown)="onKey($event)">{{toastMessage}}</div>
     `


### PR DESCRIPTION
- add strata variables to base SCSS
- update header, modal, and toastr to use SCSS
- update header, modal, and toastr styles to use strata and color variables
- add styling for button invalid tips in status bar

### To review
- [x] Start up publish local docker dev on master branch
- [x] Run `npm run build:lib:watch`
- [x] Run `CONTAINER_NAME=publishprxorg_publish npm run postbuild:lib:watch`
- [x] Run `npm install`
- [x] Run `npm run storybook`
- [x] Go to [Status Bar Usage Details](http://localhost:6006/?path=/story/navigation-status-bar--usage-details)
- [x] Inspect status bar and add `class="js-stuck` attribute to `prx-status-bar` element
- [x] Ensure the style adds a z-index to status bar
- [x] Go to publish.prx.docker
- [x] Ensure top nav, status bar, and forms stack as expected on any edit screen
- [x] Ensure modals and toasts stack as expected
- [x] Edit a series and clear one of the required fields.
- [x] Ensure save button shows an invalid tip below the status bar