### PR TITLE
Datepicker invalid input

### DIFF
--- a/projects/ngx-prx-styleguide/src/lib/datepicker/datepicker.component.stories.ts
+++ b/projects/ngx-prx-styleguide/src/lib/datepicker/datepicker.component.stories.ts
@@ -40,6 +40,7 @@ storiesOf('Forms Controls|Inputs/Date Picker', module)
     'Usage Details (Knobs)',
     () => {
       const changed = boolean('Appear Changed', false);
+      const invalid = boolean('Appear Invalid', false);
       const dateFormat = text('Date Format', 'MM/DD/YYYY');
       const useUTC = boolean('Use UTC', false);
       const today = new Date();
@@ -64,10 +65,12 @@ storiesOf('Forms Controls|Inputs/Date Picker', module)
             (dateChange)="onDateChange($event)"
             [UTC]="useUTC"
             [changed]="changed"
+            [invalid]="invalid"
           ></prx-datepicker>
         `,
         props: {
           changed,
+          invalid,
           dateFormat,
           dataDate,
           onDateChange,
@@ -94,6 +97,7 @@ __Selector__ \`prx-datepicker\`
 - \`@Input() container: ElementRef\` \\- _(optional)_ Element reference for an always open calendar picker.
 - \`@Input() date: Date | string\` \\- _(optional)_ Sets initial date of the picker.
 - \`@Input() changed: boolean = false\` \\- _(optional)_ If true, applies the class \`changed\` to the input element.
+- \`@Input() invalid: boolean = false\` \\- _(optional)_ If true, applies the class \`invalid\` to the input element.
 - \`@Input() UTC: boolean = false\` \\- _(optional)_ Have picker use and return UTC dates.
 - \`@Output() dateChange: EventEmitter<Date>\` \\- _(optional)_ Emitted when date is selected.
 `
@@ -132,4 +136,3 @@ class OpenPickerComponent {
       }
     }
   );
-

--- a/projects/ngx-prx-styleguide/src/lib/datepicker/datepicker.component.ts
+++ b/projects/ngx-prx-styleguide/src/lib/datepicker/datepicker.component.ts
@@ -69,6 +69,18 @@ export class DatepickerComponent implements AfterViewInit {
   }
   get maxDate() { return this._maxDate; }
 
+  _invalid: boolean;
+  @Input()
+  set invalid(value: boolean) { this._invalid = value; }
+  get invalid() {
+    if (this._invalid) {
+      return true;
+    } else {
+      return this.input.nativeElement.value.length > 0 &&
+        !moment(this.input.nativeElement.value, this.format, true).isValid();
+    }
+  }
+
   @Input() changed: boolean;
   @Input() UTC = false;
   @Output() dateChange = new EventEmitter<Date>();
@@ -90,11 +102,6 @@ export class DatepickerComponent implements AfterViewInit {
     } else {
       return '';
     }
-  }
-
-  get invalid(): boolean {
-    return this.input.nativeElement.value.length > 0 &&
-      !moment(this.input.nativeElement.value, this.format, true).isValid();
   }
 
   setWhenValid(value: string) {

--- a/projects/ngx-prx-styleguide/src/lib/datepicker/simpledate.spec.ts
+++ b/projects/ngx-prx-styleguide/src/lib/datepicker/simpledate.spec.ts
@@ -64,7 +64,7 @@ describe('SimpleDate', () => {
   });
 
   it('converts back to locale dates', () => {
-    const myOffset = new Date().getTimezoneOffset() / 60;
+    const myOffset = new Date(2019, 3, 1).getTimezoneOffset() / 60;
     const date = new SimpleDate('2019-04-01');
 
     const h1 = ('0' + myOffset).substr(-2, 2);

--- a/projects/ngx-prx-styleguide/src/lib/hal/remote/halremote.spec.ts
+++ b/projects/ngx-prx-styleguide/src/lib/hal/remote/halremote.spec.ts
@@ -8,13 +8,13 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 
 
 
-import { HalRemote } from './halremote';
+import { HalRemote, HalHttpError } from './halremote';
 
 describe('HalRemote', () => {
 
   let mockHttp: HttpTestingController;
   let httpClient: HttpClient;
- 
+
   let remote: HalRemote, link: any, token: ReplaySubject<string>, fakeAuth: any;
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -171,6 +171,19 @@ describe('HalRemote', () => {
         expect(completed).toEqual(3);
         done();
       }, 200);
+    });
+
+    it('returns hal errors', () => {
+      let caught: any;
+      remote.get(link).subscribe(() => {}, err => caught = err);
+
+      const req = mockHttp.expectOne(() => true);
+      req.flush('{"what":"ever"}', {status: 500, statusText: 'bad things'});
+
+      expect(caught instanceof HalHttpError).toEqual(true)
+      expect(caught.status).toEqual(500);
+      expect(caught.message).toMatch('Got 500 from GET http://thehost/foobar');
+      expect(caught.body).toEqual({what: 'ever'});
     });
 
   });

--- a/projects/ngx-prx-styleguide/src/lib/hal/remote/halremote.ts
+++ b/projects/ngx-prx-styleguide/src/lib/hal/remote/halremote.ts
@@ -19,7 +19,7 @@ export class HalHttpError extends Error {
     super(msg);
 
     // make instanceof work as expected
-    Object.setPrototypeOf(this, HalHttpError.prototype)
+    Object.setPrototypeOf(this, HalHttpError.prototype);
   }
 }
 

--- a/projects/ngx-prx-styleguide/src/lib/hal/remote/halremote.ts
+++ b/projects/ngx-prx-styleguide/src/lib/hal/remote/halremote.ts
@@ -15,8 +15,11 @@ import { HalLink, HalLinkError } from '../doc/hallink';
 
 export class HalHttpError extends Error {
   name = 'HalHttpError';
-  constructor(public status: number, msg: string) {
+  constructor(public status: number, msg: string, public body?: {}) {
     super(msg);
+
+    // make instanceof work as expected
+    Object.setPrototypeOf(this, HalHttpError.prototype)
   }
 }
 
@@ -121,7 +124,15 @@ export class HalRemote {
         } else if (err.status === 0) {
           return observableThrowError(new Error(`CORS preflight failed for ${method.toUpperCase()} ${href}`));
         } else {
-          return observableThrowError(new HalHttpError(err.status, `Got ${err.status} from ${method.toUpperCase()} ${href}`));
+          const msg = `Got ${err.status} from ${method.toUpperCase()} ${href}`;
+
+          // attempt to json-decode error body
+          let errBody = err.error;
+          if (typeof(errBody) === 'string') {
+            try { errBody = JSON.parse(errBody); } catch (_err) {}
+          }
+
+          return observableThrowError(new HalHttpError(err.status, msg, errBody));
         }
       } else {
         throw err;

--- a/projects/ngx-prx-styleguide/src/lib/tz-datepicker/tz-datepicker.component.css
+++ b/projects/ngx-prx-styleguide/src/lib/tz-datepicker/tz-datepicker.component.css
@@ -16,6 +16,9 @@ input, select, prx-datepicker >>> input, ng-select >>> input {
 .changed {
   outline: 5px auto #f09b4c;
 }
+.invalid {
+  outline: 5px auto #e32;
+}
 
 input.ng-dirty.ng-invalid,
 prx-datepicker.invalid,

--- a/projects/ngx-prx-styleguide/src/lib/tz-datepicker/tz-datepicker.component.stories.ts
+++ b/projects/ngx-prx-styleguide/src/lib/tz-datepicker/tz-datepicker.component.stories.ts
@@ -22,17 +22,20 @@ storiesOf('Forms Controls|Inputs/Timezone Datepicker', module)
     () => {
       const date = dateKnob('Date', new Date(Date.UTC(2018, 2, 16, 2, 0, 0, 0)));
       const changed = boolean('Date Changed', false);
+      const invalid = boolean('Date Invalid', false);
       const dateChange = action('Date Change');
 
       return {
         template: `
           <div class="centered-wrapper">
-            <prx-tz-datepicker (dateChange)="dateChange($event)" [date]="date" [changed]="changed"></prx-tz-datepicker>
+            <prx-tz-datepicker (dateChange)="dateChange($event)" [date]="date"
+              [changed]="changed" [invalid]="invalid"></prx-tz-datepicker>
           </div>
         `,
         props: {
           date,
           changed,
+          invalid,
           dateChange
         }
       };
@@ -54,6 +57,7 @@ __Selector__ \`prx-tz-datepicker\`
 
 - \`@Input() date: Date | string\` \\- _(optional)_ Sets initial date of the picker.
 - \`@Input() changed: boolean = false\` \\- _(optional)_ If true, applies the class \`changed\` to the input element.
+- \`@Input() invalid: boolean = false\` \\- _(optional)_ If true, applies the class \`invalid\` to the input element.
 - \`@Output() dateChange: EventEmitter<Date>\` \\- _(optional)_ Emitted when date is selected.
 `
       }

--- a/projects/ngx-prx-styleguide/src/lib/tz-datepicker/tz-datepicker.component.ts
+++ b/projects/ngx-prx-styleguide/src/lib/tz-datepicker/tz-datepicker.component.ts
@@ -16,12 +16,14 @@ const moment = momentNs;
         [date]="this.model.pickerDate"
         (dateChange)="this.model.pickerDate = $event; handleChange()"
         [changed]="changed"
+        [invalid]="invalid"
       >
       </prx-datepicker>
       <span *ngIf="!supportsTimeInput; else supportsTime">
         <span>
           <input
             [class.changed]="changed"
+            [class.invalid]="invalid"
             [(ngModel)]="model.time"
             (ngModelChange)="handleChange()"
             name="time"
@@ -32,6 +34,7 @@ const moment = momentNs;
           />
           <select
             [class.changed]="changed"
+            [class.invalid]="invalid"
             [(ngModel)]="model.meridiem"
             (ngModelChange)="handleChange()"
             name="meridiem"
@@ -52,6 +55,7 @@ const moment = momentNs;
       <ng-template #supportsTime>
         <input
           [class.changed]="changed"
+          [class.invalid]="invalid"
           [(ngModel)]="model.time"
           (ngModelChange)="handleChange()"
           name="time"
@@ -66,6 +70,7 @@ const moment = momentNs;
         ngDefaultControl
         name="timezone"
         [class.changed]="changed"
+        [class.invalid]="invalid"
         [items]="timezones | async"
         bindLabel="label"
         bindValue="name"
@@ -93,6 +98,7 @@ export class TzDatepickerComponent implements OnInit {
   }
   @Output() dateChange = new EventEmitter<Date>();
   @Input() changed: boolean;
+  @Input() invalid: boolean;
 
   supportsTimeInput = false;
 

--- a/projects/ngx-prx-styleguide/src/public_api.ts
+++ b/projects/ngx-prx-styleguide/src/public_api.ts
@@ -33,6 +33,7 @@ export { HalService } from './lib/hal/hal.service';
 export { HalBaseService } from './lib/hal/hal-base.service';
 export { HalDoc } from './lib/hal/doc/haldoc';
 export { HalObservable } from './lib/hal/doc/halobservable';
+export { HalHttpError } from './lib/hal/remote/halremote';
 export { MockHalService } from './lib/hal/mock/mock-hal.service';
 export { MockHalDoc } from './lib/hal/mock/mock-haldoc';
 


### PR DESCRIPTION
- Add a red "invalid" state border to datepickers (setup for PRX/publish.prx.org#702)
- Surface the response body in HalHttpErrors