### PR TITLE
Use explicit AWS URL for EvaporateJS

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,6 +4,9 @@ env:
     PRX_ECR_REGION: "us-east-1"
     PRX_ECR_REPOSITORY: "styleguide.prx.org"
     PRX_ECR_CONFIG_PARAMETERS: "StyleguideEcrImageTag"
+  parameter-store:
+    DOCKERHUB_USERNAME: '/prx/DOCKERHUB_USERNAME'
+    DOCKERHUB_PASSWORD: '/prx/DOCKERHUB_PASSWORD'
 phases:
   install:
     runtime-versions:

--- a/env-example
+++ b/env-example
@@ -11,12 +11,11 @@ AUTH_CLIENT_ID=XrGAyTW8NEpgNd48osQP3lHySrTIf4UpqmTyNcpC
 # AUTH_CLIENT_ID=labJFTe1vsEaTtc7QbAYGGGjOKMlS87u7Jrh2ibc
 
 # aws uploading
-BUCKET_NAME=prx-up
-BUCKET_FOLDER=dev
-SIGN_URL=your-signing-url
-AWS_KEY=your-aws-key
-AWS_URL=your-cloudfront-url
-USE_CLOUDFRONT=true
+UPLOAD_S3_ENDPOINT_URL=your-cloudfront-url
+UPLOAD_BUCKET_NAME=prx-up
+UPLOAD_BUCKET_FOLDER=dev
+UPLOAD_SIGNING_SERVICE_URL=your-signing-url
+UPLOAD_SIGNING_SERVICE_KEY_ID=aws-key-used-by-signing-service
 
 # dev server
 PORT=6006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "PRX Angular style guide library",
   "keywords": [
     "PRX",

--- a/projects/ngx-prx-styleguide/src/lib/upload/service/upload.service.spec.ts
+++ b/projects/ngx-prx-styleguide/src/lib/upload/service/upload.service.spec.ts
@@ -4,9 +4,9 @@ import { MimeDefinition } from './mime-type.service';
 
 describe('UploadService', () => {
   const specConfig = {
+    awsUrl: 'url://',
     bucketName: 'baz',
     bucketFolder: 'asd',
-    bucketAccel: false,
     signUrl: 'foo',
     awsKey: 'bar'
   }

--- a/projects/ngx-prx-styleguide/src/lib/upload/service/upload.service.ts
+++ b/projects/ngx-prx-styleguide/src/lib/upload/service/upload.service.ts
@@ -97,30 +97,29 @@ export class UploadService {
   public uploads: Upload[] = [];
 
   private evaporate: Observable<Evaporate>;
+  private awsUrl: string;
   private bucketName: string;
   private bucketFolder: string;
-  private bucketAccel: boolean;
   private signUrl: string;
   private awsKey: string;
 
   constructor(private mimeTypeService: MimeTypeService) {}
 
   createWithConfig({
+    awsUrl,
     bucketName,
     bucketFolder,
-    bucketAccel,
     signUrl,
     awsKey
   }: {
+    awsUrl: string;
     bucketName: string;
     bucketFolder: string;
-    bucketAccel: boolean;
     signUrl: string;
     awsKey: string;
   }) {
     this.bucketName = bucketName;
     this.bucketFolder = bucketFolder;
-    this.bucketAccel = bucketAccel;
     this.signUrl = signUrl;
     this.awsKey = awsKey;
     this.evaporate = this.init();
@@ -130,10 +129,11 @@ export class UploadService {
     // until there is a good way to load from env and inject
     return observableFrom(
       Evaporate.create({
+        aws_url: this.awsUrl,
+        cloudfront: true, // Must be set when using custom aws_url
         signerUrl: this.signUrl,
         aws_key: this.awsKey,
         bucket: this.bucketName,
-        s3Acceleration: this.bucketAccel,
         onlyRetryForSameFileName: true,
         logging: false,
         awsSignatureVersion: '4',

--- a/projects/ngx-prx-styleguide/src/lib/upload/service/upload.service.ts
+++ b/projects/ngx-prx-styleguide/src/lib/upload/service/upload.service.ts
@@ -118,6 +118,7 @@ export class UploadService {
     signUrl: string;
     awsKey: string;
   }) {
+    this.awsUrl = awsUrl;
     this.bucketName = bucketName;
     this.bucketFolder = bucketFolder;
     this.signUrl = signUrl;


### PR DESCRIPTION
Makes the upload service take an explicit S3 URL to be used by EvaporateJS. This prevents Evaporate from constructing the URL based on other parameters, and allows for supporting S3 endpoints that Evaporate does not, such as dualstack endpoints. When a aws_url is used, the cloudfront parameter must be set, so this change hard codes that value.