### PR TITLE
Remove public-read ACL for S3 uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "PRX Angular style guide library",
   "keywords": [
     "PRX",

--- a/projects/ngx-prx-styleguide/package.json
+++ b/projects/ngx-prx-styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-prx-styleguide",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "PRX Angular 2 style guide library",
   "keywords": [
     "PRX",

--- a/projects/ngx-prx-styleguide/src/lib/upload/service/upload.service.ts
+++ b/projects/ngx-prx-styleguide/src/lib/upload/service/upload.service.ts
@@ -68,9 +68,6 @@ export class Upload {
       file: this.file,
       name: this.path,
       contentType: this.contentType,
-      xAmzHeadersAtInitiate: {
-        'x-amz-acl': 'public-read'
-      },
       notSignedHeadersAtInitiate: {
         'Content-Disposition': 'attachment; filename=' + this.sanitizedName()
       }


### PR DESCRIPTION
Closes #224 

I'm just assuming there's no requirement for the `xAmzHeadersAtInitiate` key to exist.