### PR TITLE
Restrict total audio size

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,6 +5,9 @@ env:
   parameter-store:
     DOCKERHUB_USERNAME: '/prx/DOCKERHUB_USERNAME'
     DOCKERHUB_PASSWORD: '/prx/DOCKERHUB_PASSWORD'
+  exported-variables:
+    - PRX_ECR_CONFIG_PARAMETERS
+    - PRX_ECR_IMAGE
 phases:
   install:
     runtime-versions:
@@ -24,4 +27,4 @@ phases:
       - "docker-compose build"
   post_build:
     commands:
-      - 'curl -sO "https://raw.githubusercontent.com/PRX/Infrastructure/master/ci/utility/post_build.sh" && chmod +x post_build.sh && bash ./post_build.sh'
+      - 'curl -sO "https://raw.githubusercontent.com/PRX/Infrastructure/master/ci/utility/post_build.sh" && chmod +x post_build.sh && . ./post_build.sh'

--- a/projects/ngx-prx-styleguide/src/lib/upload/model/invalid/audio.invalid.spec.ts
+++ b/projects/ngx-prx-styleguide/src/lib/upload/model/invalid/audio.invalid.spec.ts
@@ -63,7 +63,7 @@ describe('AudioInvalid', () => {
       const invalid = VERSION_TEMPLATED();
       expect(invalid('', {files: []}, false)).toBeNull();
       expect(invalid('', {files: [{size: 249 * 1024 * 1024}]}, true)).toBeNull();
-      expect(invalid('', {files: [{}, {size: 251 * 1024 * 1024}]}, true)).toMatch('must be less than 250 MB');
+      expect(invalid('', {files: [{}, {size: 251 * 1024 * 1024}]}, true)).toMatch('must be less than 250 MiB');
     });
 
   });

--- a/projects/ngx-prx-styleguide/src/lib/upload/model/invalid/audio.invalid.spec.ts
+++ b/projects/ngx-prx-styleguide/src/lib/upload/model/invalid/audio.invalid.spec.ts
@@ -10,50 +10,50 @@ describe('AudioInvalid', () => {
     };
 
     it('strictly defaults to at least one segment', () => {
-      let invalid = VERSION_TEMPLATED();
+      const invalid = VERSION_TEMPLATED();
       expect(invalid('', {files: []}, false)).toBeNull();
       expect(invalid('', {files: []}, true)).toMatch('upload at least 1 segment');
       expect(invalid('', {files: [1]}, true)).toBeNull();
     });
 
     it('strictly checks segment count', () => {
-      let invalid = VERSION_TEMPLATED(build({}, 3));
+      const invalid = VERSION_TEMPLATED(build({}, 3));
       expect(invalid('', {files: [1, 2]}, false)).toBeNull();
       expect(invalid('', {files: [1, 2]}, true)).toMatch('upload 3 segment');
       expect(invalid('', {files: [1, 2, 3]}, true)).toBeNull();
     });
 
     it('ignores destroyed segments', () => {
-      let invalid = VERSION_TEMPLATED(build({}, 3));
-      let f1: any = {}, f2: any = {}, f3: any = {};
+      const invalid = VERSION_TEMPLATED(build({}, 3));
+      const f1: any = {}, f2: any = {}, f3: any = {};
       expect(invalid('', {files: [f1, f2, f3]}, true)).toBeNull();
       f2.isDestroy = true;
       expect(invalid('', {files: [f1, f2, f3]}, true)).toMatch('upload 3 segment');
     });
 
     it('strictly waits for processing', () => {
-      let invalid = VERSION_TEMPLATED();
+      const invalid = VERSION_TEMPLATED();
       expect(invalid('', {files: [{}, {isProcessing: true}]}, true)).toMatch('wait for uploads');
       expect(invalid('', {files: [{}, {isProcessing: true}]}, false)).toBeNull();
       expect(invalid('', {files: [{}, {isProcessing: false}]}, true)).toBeNull();
     });
 
     it('strictly checks min duration', () => {
-      let invalid = VERSION_TEMPLATED(build({lengthMinimum: 10}));
+      const invalid = VERSION_TEMPLATED(build({lengthMinimum: 10}));
       expect(invalid('', {files: [{duration: 3}, {duration: 2}]}, false)).toBeNull();
       expect(invalid('', {files: [{duration: 3}, {duration: 2}]}, true)).toMatch('must be greater than 0:00:10');
       expect(invalid('', {files: [{duration: 3}, {duration: 8}]}, true)).toBeNull();
     });
 
     it('strictly checks max duration', () => {
-      let invalid = VERSION_TEMPLATED(build({lengthMaximum: 10}));
+      const invalid = VERSION_TEMPLATED(build({lengthMaximum: 10}));
       expect(invalid('', {files: [{duration: 3}, {duration: 8}]}, false)).toBeNull();
       expect(invalid('', {files: [{duration: 3}, {duration: 8}]}, true)).toMatch('must be less than 0:00:10');
       expect(invalid('', {files: [{duration: 3}, {duration: 2}]}, true)).toBeNull();
     });
 
     it('strictly checks matching audio formats', () => {
-      let invalid = VERSION_TEMPLATED();
+      const invalid = VERSION_TEMPLATED();
       expect(invalid('', {files: [{bitrate: 123}, {bitrate: 456}]}, false)).toBeNull();
       expect(invalid('', {files: [{bitrate: 123}, {bitrate: 456}]}, true)).toMatch('Non-matching');
       expect(invalid('', {files: [{bitrate: 123}, {bitrate: 123}]}, true)).toBeNull();
@@ -64,7 +64,7 @@ describe('AudioInvalid', () => {
   describe('FILE_TEMPLATED', () => {
 
     it('only accepts mp3 files', () => {
-      let invalid = FILE_TEMPLATED(<any> {contentType: 'audio/mpeg'});
+      const invalid = FILE_TEMPLATED(<any> {contentType: 'audio/mpeg'});
       expect(invalid('', {format: 'mp2'})).toMatch('not an mp3');
       expect(invalid('', {format: 'm4a'})).toMatch('not an mp3');
       expect(invalid('', {format: 'mp3', duration: 1})).toBeNull();
@@ -72,13 +72,13 @@ describe('AudioInvalid', () => {
     });
 
     it('does not validate video files', () => {
-      let invalid = FILE_TEMPLATED(<any> {contentType: 'video/mpeg'});
+      const invalid = FILE_TEMPLATED(<any> {contentType: 'video/mpeg'});
       expect(invalid('', {format: 'whatev'})).toBeNull();
       expect(invalid('', {contenttype: 'whatev'})).toBeNull();
     });
 
     it('requires a duration', () => {
-      let invalid = FILE_TEMPLATED(<any> {contentType: 'audio/mpeg'});
+      const invalid = FILE_TEMPLATED(<any> {contentType: 'audio/mpeg'});
       expect(invalid('', {})).toMatch('not an audio file');
       expect(invalid('', {duration: null})).toMatch('not an audio file');
       expect(invalid('', {duration: 0})).toBeNull();
@@ -86,13 +86,13 @@ describe('AudioInvalid', () => {
     });
 
     it('checks min duration', () => {
-      let invalid = FILE_TEMPLATED(null, <any> {lengthMinimum: 7});
+      const invalid = FILE_TEMPLATED(null, <any> {lengthMinimum: 7});
       expect(invalid('', {duration: 2})).toMatch('must be greater than 0:00:07');
       expect(invalid('', {duration: 8})).toBeNull();
     });
 
     it('checks max duration', () => {
-      let invalid = FILE_TEMPLATED(null, <any> {lengthMaximum: 7});
+      const invalid = FILE_TEMPLATED(null, <any> {lengthMaximum: 7});
       expect(invalid('', {duration: 8})).toMatch('must be less than 0:00:07');
       expect(invalid('', {duration: 6})).toBeNull();
     });

--- a/projects/ngx-prx-styleguide/src/lib/upload/model/invalid/audio.invalid.spec.ts
+++ b/projects/ngx-prx-styleguide/src/lib/upload/model/invalid/audio.invalid.spec.ts
@@ -59,6 +59,13 @@ describe('AudioInvalid', () => {
       expect(invalid('', {files: [{bitrate: 123}, {bitrate: 123}]}, true)).toBeNull();
     });
 
+    it('strictly checks for total file size < 250mb', () => {
+      const invalid = VERSION_TEMPLATED();
+      expect(invalid('', {files: []}, false)).toBeNull();
+      expect(invalid('', {files: [{size: 249 * 1024 * 1024}]}, true)).toBeNull();
+      expect(invalid('', {files: [{}, {size: 251 * 1024 * 1024}]}, true)).toMatch('must be less than 250 MB');
+    });
+
   });
 
   describe('FILE_TEMPLATED', () => {

--- a/projects/ngx-prx-styleguide/src/lib/upload/model/invalid/audio.invalid.ts
+++ b/projects/ngx-prx-styleguide/src/lib/upload/model/invalid/audio.invalid.ts
@@ -59,6 +59,12 @@ export const VERSION_TEMPLATED = (template?: HalDoc): BaseInvalid => {
       if (nonMatches.length) {
         return `Non-matching audio files (${nonMatches.join(' / ')})`;
       }
+
+      // max total file size (250mb)
+      const totalSize = undeleted.reduce((acc, f) => acc + (f.size || 0), 0);
+      if (totalSize > (250 * 1024 * 1024)) {
+        return 'Total audio file size must be less than 250 MB';
+      }
     }
 
     return null;

--- a/projects/ngx-prx-styleguide/src/lib/upload/model/invalid/audio.invalid.ts
+++ b/projects/ngx-prx-styleguide/src/lib/upload/model/invalid/audio.invalid.ts
@@ -63,7 +63,7 @@ export const VERSION_TEMPLATED = (template?: HalDoc): BaseInvalid => {
       // max total file size (250mb)
       const totalSize = undeleted.reduce((acc, f) => acc + (f.size || 0), 0);
       if (totalSize > (250 * 1024 * 1024)) {
-        return 'Total audio file size must be less than 250 MB';
+        return 'Total audio file size must be less than 250 MiB';
       }
     }
 


### PR DESCRIPTION
Closes PRX/dovetail-stitch-lambda#62.

Real basic validation for Publish, that total audio file size is < 250mb.  I don't think I'm even going to add this validation to CMS - Publish is probably enough to get us by until the new Dovetail 3 CDN can stop using the disk so much.

![image](https://user-images.githubusercontent.com/1410587/121748869-f5bbe800-cac6-11eb-8a58-3f14950545fd.png)
