### PR TITLE
Check token aurs instead of asking for apps scope

### DIFF
--- a/projects/ngx-prx-styleguide/src/lib/auth/auth-parser.ts
+++ b/projects/ngx-prx-styleguide/src/lib/auth/auth-parser.ts
@@ -1,7 +1,6 @@
 import { ElementRef } from '@angular/core';
 
 export class AuthParser {
-
   static parseIframeQuery(el: ElementRef) {
     const iframe = el.nativeElement.getElementsByTagName('iframe')[0];
     return this.parseQuery(iframe.contentDocument.location.hash);
@@ -28,4 +27,11 @@ export class AuthParser {
     return AuthParser.queryToPairs(query)['error'];
   }
 
+  static decodeToken(token = ''): object {
+    try {
+      return JSON.parse(window.atob(token.split('.')[1]));
+    } catch (e) {
+      return null;
+    }
+  }
 }

--- a/projects/ngx-prx-styleguide/src/lib/auth/auth.service.ts
+++ b/projects/ngx-prx-styleguide/src/lib/auth/auth.service.ts
@@ -1,12 +1,9 @@
-
-import {skip} from 'rxjs/operators';
+import { skip } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
-import { Observable ,  ReplaySubject } from 'rxjs';
-
+import { Observable, ReplaySubject } from 'rxjs';
 
 @Injectable()
 export class AuthService {
-
   static AUTHORIZATION_DENIED = 'AUTHORIZATION_DENIED';
 
   authHost: string;
@@ -26,7 +23,7 @@ export class AuthService {
       url = url.match(/\.org|\.tech/) ? `https://${url}` : `http://${url}`;
     }
     const nonce = this.getNonce();
-    return `${url}&nonce=${nonce}&response_type=token&scope=apps&prompt=${prompt}`;
+    return `${url}&nonce=${nonce}&response_type=token&prompt=${prompt}`;
   }
 
   setToken(authToken: string) {
@@ -52,7 +49,9 @@ export class AuthService {
   }
 
   parseToken(tokStr: string) {
-    if (tokStr === AuthService.AUTHORIZATION_DENIED) { return false; }
+    if (tokStr === AuthService.AUTHORIZATION_DENIED) {
+      return false;
+    }
 
     // https://stackoverflow.com/questions/38552003/how-to-decode-jwt-token-in-javascript
     let base64decoded = tokStr.replace(/-/g, '+').replace(/_/g, '/');
@@ -86,5 +85,4 @@ export class AuthService {
   private randomInt(low: number, high: number): number {
     return Math.floor(Math.random() * (high - low + 1) + low);
   }
-
 }


### PR DESCRIPTION
Account applications (and the `scope=apps`) are being deprecated.

Instead, check if the actual JWT `aur` is empty.  If it is, you don't have permission to use the app.